### PR TITLE
[#19] 사용자별 포스트 목록 API 구현 및 리팩토링

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -63,8 +63,8 @@ public class PostController {
 	
 	@GetMapping()
 	@Operation(summary = "전체 포스트", description = "로그인한 사용자의 전체 포스트를 가져옵니다.")
-	public ApiResponse<List<PostResponse.PosOverview>> getOverview(@AuthenticationPrincipal User user) {
-		List<PostResponse.PosOverview> posts = postService.getAllPostsByUser(user);
+	public ApiResponse<List<PostResponse.PostOverview>> getOverview(@AuthenticationPrincipal User user) {
+		List<PostResponse.PostOverview> posts = postService.getAllPostsByUser(user);
 		return ApiResponse.onSuccess(posts);
 	}
 

--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.controller;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,6 +56,13 @@ public class PostController {
 	public ApiResponse<Void> deletePost(@PathVariable("postId") Long postId) {
 		postService.deletePost(postId);
 		return ApiResponse.onSuccess(null);
+	}
+	
+	@GetMapping()
+	@Operation(summary = "전체 포스트", description = "로그인한 사용자의 전체 포스트를 가져옵니다.")
+	public ApiResponse<List<PostResponse.PosOverview>> getOverview(@AuthenticationPrincipal User user) {
+		List<PostResponse.PosOverview> posts = postService.getAllPostsByUser(user);
+		return ApiResponse.onSuccess(posts);
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -38,23 +38,26 @@ public class PostController {
 	
 	@GetMapping("/{postId}")
 	@Operation(summary = "포스트 읽기", description = "읽어오길 원하는 포스트 번호를 입력해주세요.")
-	public ApiResponse<PostResponse.PostInfo> getPost(@PathVariable("postId") Long postId) {
-		PostResponse.PostInfo info =  postService.getPost(postId);
+	public ApiResponse<PostResponse.PostInfo> getPost(@AuthenticationPrincipal User user, 
+														@PathVariable("postId") Long postId) {
+		PostResponse.PostInfo info =  postService.getPost(user, postId);
 		return ApiResponse.onSuccess(info);
 	}
 	
 	@PutMapping("/{postId}")
 	@Operation(summary = "포스트 수정", description = "수정할 포스트 내용을 입력해주세요.")
-	public ApiResponse<PostResponse.PostInfo> updatePost(@PathVariable("postId") Long postId,
-											@RequestBody PostRequest.PostCommand command) {
-		PostResponse.PostInfo info =  postService.updatePost(postId, command);
+	public ApiResponse<PostResponse.PostInfo> updatePost(@AuthenticationPrincipal User user, 
+														@PathVariable("postId") Long postId,
+														@RequestBody PostRequest.PostCommand command) {
+		PostResponse.PostInfo info =  postService.updatePost(user, postId, command);
 		return ApiResponse.onSuccess(info);
 	}
 	
 	@DeleteMapping("/{postId}")
 	@Operation(summary = "포스트 삭제", description = "삭제할 포스트 번호를 입력해주세요.")
-	public ApiResponse<Void> deletePost(@PathVariable("postId") Long postId) {
-		postService.deletePost(postId);
+	public ApiResponse<Void> deletePost(@AuthenticationPrincipal User user, 
+										@PathVariable("postId") Long postId) {
+		postService.deletePost(user, postId);
 		return ApiResponse.onSuccess(null);
 	}
 	

--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -28,33 +28,32 @@ public class PostController {
 	
 	@PostMapping()
 	@Operation(summary = "포스트 생성", description = "포스트 내용을 입력해주세요. 단, 로그인 상태여야 합니다.")
-	public ApiResponse<PostResponse> createPost(@AuthenticationPrincipal User user, 
-												@RequestBody PostRequest request) {
-		PostResponse response = postService.createPost(user, request);
-		return ApiResponse.onSuccess(response);
+	public ApiResponse<PostResponse.PostInfo> createPost(@AuthenticationPrincipal User user, 
+												@RequestBody PostRequest.PostCommand command) {
+		PostResponse.PostInfo info = postService.createPost(user, command);
+		return ApiResponse.onSuccess(info);
 	}
 	
 	@GetMapping("/{postId}")
 	@Operation(summary = "포스트 읽기", description = "읽어오길 원하는 포스트 번호를 입력해주세요.")
-	public ApiResponse<PostResponse> getPost(@PathVariable("postId") Long postId) {
-		PostResponse response =  postService.getPost(postId);
-		return ApiResponse.onSuccess(response);
+	public ApiResponse<PostResponse.PostInfo> getPost(@PathVariable("postId") Long postId) {
+		PostResponse.PostInfo info =  postService.getPost(postId);
+		return ApiResponse.onSuccess(info);
 	}
 	
 	@PutMapping("/{postId}")
 	@Operation(summary = "포스트 수정", description = "수정할 포스트 내용을 입력해주세요.")
-	public ApiResponse<PostResponse> updatePost(@PathVariable("postId") Long postId,
-											@RequestBody PostRequest request) {
-		PostResponse response =  postService.updatePost(postId, request);
-		return ApiResponse.onSuccess(response);
+	public ApiResponse<PostResponse.PostInfo> updatePost(@PathVariable("postId") Long postId,
+											@RequestBody PostRequest.PostCommand command) {
+		PostResponse.PostInfo info =  postService.updatePost(postId, command);
+		return ApiResponse.onSuccess(info);
 	}
 	
 	@DeleteMapping("/{postId}")
 	@Operation(summary = "포스트 삭제", description = "삭제할 포스트 번호를 입력해주세요.")
-	public ApiResponse<Long> deletePost(@PathVariable("postId") Long postId) {
-		Long deletedId = postService.deletePost(postId);
-		return ApiResponse.onSuccess(deletedId);
+	public ApiResponse<Void> deletePost(@PathVariable("postId") Long postId) {
+		postService.deletePost(postId);
+		return ApiResponse.onSuccess(null);
 	}
-
 
 }

--- a/src/main/java/com/doyak/reflector/converter/PostConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/PostConverter.java
@@ -43,9 +43,9 @@ public class PostConverter {
     }
 
     // 리스트 
-    public List<PostResponse.PosOverview> toResponseList(List<Post> posts) {    	
+    public List<PostResponse.PostOverview> toResponseList(List<Post> posts) {    	
     	return posts.stream()
-    		.map(post -> PostResponse.PosOverview.builder()
+    		.map(post -> PostResponse.PostOverview.builder()
     				.postId(post.getPostId())
     				.title(post.getTitle())
     				.level(post.getLevel())

--- a/src/main/java/com/doyak/reflector/converter/PostConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/PostConverter.java
@@ -4,6 +4,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -42,12 +43,14 @@ public class PostConverter {
     }
 
     // 리스트 
-    public List<PostResponse.PostInfo> toResponseList(List<Post> posts) {
-    	return Optional.ofNullable(posts)
-                .orElse(Collections.emptyList())
-                .stream()
-                .map(this::toResponse)
-                .toList();
-
+    public List<PostResponse.PosOverview> toResponseList(List<Post> posts) {    	
+    	return posts.stream()
+    		.map(post -> PostResponse.PosOverview.builder()
+    				.postId(post.getPostId())
+    				.title(post.getTitle())
+    				.level(post.getLevel())
+    				.site(post.getSite())
+    				.build())
+        .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/doyak/reflector/converter/PostConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/PostConverter.java
@@ -1,12 +1,13 @@
 package com.doyak.reflector.converter;
 
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.doyak.reflector.domain.Post;
-import com.doyak.reflector.domain.Post.PostBuilder;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.PostRequest;
 import com.doyak.reflector.dto.response.PostResponse;
@@ -15,37 +16,38 @@ import com.doyak.reflector.dto.response.PostResponse;
 public class PostConverter {
 
     // 생성
-    public Post toEntity(PostRequest request, User user) {
+    public Post toEntity(PostRequest.PostCommand command, User user) {
         return Post.builder()
-        		.site(request.getSite())
-        		.level(request.getLevel())
-        		.title(request.getTitle())
-        		.content(request.getContent())
+        		.site(command.getSite())
+        		.level(command.getLevel())
+        		.title(command.getTitle())
+        		.content(command.getContent())
         		.user(user)
         		.build();
     }
 
-    // 업데이트
-    public void updateEntity(Post post, PostRequest request) {
-        post.update(request.getSite(),
-                    request.getLevel(),
-                    request.getTitle(),
-                    request.getContent());
-    }
-
     // 단일 
-    public PostResponse toResponse(Post post) {
-        return new PostResponse(post.getPostId(),
-                                post.getSite(),
-                                post.getLevel(),
-                                post.getTitle(),
-                                post.getContent());
+    public PostResponse.PostInfo toResponse(Post post) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return PostResponse.PostInfo.builder()
+        			.postId(post.getPostId())
+        			.site(post.getSite())
+        			.level(post.getLevel())
+        			.title(post.getTitle())
+        			.content(post.getContent())
+        			.author(post.getUser().getEmail())
+        			.createdAt(post.getCreatedAt().format(formatter))
+        			.updatedAt(post.getUpdatedAt().format(formatter))
+        			.build();
     }
 
     // 리스트 
-    public List<PostResponse> toResponseList(List<Post> posts) {
-        return posts.stream()
-                    .map(this::toResponse)
-                    .collect(Collectors.toList());
+    public List<PostResponse.PostInfo> toResponseList(List<Post> posts) {
+    	return Optional.ofNullable(posts)
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+
     }
 }

--- a/src/main/java/com/doyak/reflector/domain/Post.java
+++ b/src/main/java/com/doyak/reflector/domain/Post.java
@@ -2,7 +2,6 @@ package com.doyak.reflector.domain;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import com.doyak.reflector.domain.common.BaseEntity;
 import com.doyak.reflector.domain.enums.Site;

--- a/src/main/java/com/doyak/reflector/domain/common/BaseEntity.java
+++ b/src/main/java/com/doyak/reflector/domain/common/BaseEntity.java
@@ -6,7 +6,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 public abstract class BaseEntity {
 	

--- a/src/main/java/com/doyak/reflector/dto/request/PostRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/PostRequest.java
@@ -2,16 +2,29 @@ package com.doyak.reflector.dto.request;
 
 import com.doyak.reflector.domain.enums.Site;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class PostRequest {
-	private Site site;
-	private Integer level;
-	private String title;
-	private String content;
+
+	@Builder
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class PostCommand {
+		
+		@NotNull
+		private Site site;
+		private Integer level;
+		
+		@NotBlank
+		private String title;
+		@NotBlank
+		private String content;
+	}
 }

--- a/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
@@ -2,4 +2,26 @@ package com.doyak.reflector.dto.response;
 
 import com.doyak.reflector.domain.enums.Site;
 
-public record PostResponse(Long postId, Site site, Integer level, String title, String content) {}
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PostResponse {
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class PostInfo {
+		private Long postId;
+		private Site site;
+		private Integer level;
+		private String title;
+		private String content;	
+		private String author;
+		private String createdAt;
+	    private String updatedAt;
+	}
+}

--- a/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
@@ -29,7 +29,7 @@ public class PostResponse {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter
-	public static class PosOverview {
+	public static class PostOverview {
 		private Long postId;
 		private Site site;
 		private Integer level;

--- a/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
@@ -24,4 +24,15 @@ public class PostResponse {
 		private String createdAt;
 	    private String updatedAt;
 	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class PosOverview {
+		private Long postId;
+		private Site site;
+		private Integer level;
+		private String title;
+	}
 }

--- a/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	
     // Post
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST4002", "다른 사용자의 게시글입니다."),
 
 	// JWT 토큰 관련 에러 
 	NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponse.PosOverview> getAllPostsByUser(User user) {
+    public List<PostResponse.PostOverview> getAllPostsByUser(User user) {
         List<Post> posts = postRepository.findAllByUserOrderByCreatedAtDesc(user);
         return postConverter.toResponseList(posts);
     }

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -3,6 +3,7 @@ package com.doyak.reflector.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.doyak.reflector.converter.PostConverter;
 import com.doyak.reflector.domain.Post;
@@ -13,7 +14,6 @@ import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
 import com.doyak.reflector.repository.PostRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -24,33 +24,33 @@ public class PostService {
     private final PostConverter postConverter;
 
     @Transactional
-    public PostResponse createPost(User user, PostRequest request) {
-        Post post = postConverter.toEntity(request, user);
+    public PostResponse.PostInfo createPost(User user, PostRequest.PostCommand command) {
+        Post post = postConverter.toEntity(command, user);
         Post saved = postRepository.save(post);
         return postConverter.toResponse(saved);
     }
 
-    public PostResponse getPost(Long postId) {
+    @Transactional(readOnly = true)
+    public PostResponse.PostInfo getPost(Long postId) {
         Post post = findPostById(postId);
         return postConverter.toResponse(post);
     }
 
     @Transactional
-    public PostResponse updatePost(Long postId, PostRequest request) {
+    public PostResponse.PostInfo updatePost(Long postId, PostRequest.PostCommand command) {
         Post post = findPostById(postId);
-        postConverter.updateEntity(post, request);
-        Post updated = postRepository.save(post);
-        return postConverter.toResponse(updated);
+        post.update(command.getSite(), command.getLevel(), command.getTitle(), command.getContent());
+        return postConverter.toResponse(post);
     }
 
     @Transactional
-    public Long deletePost(Long postId) {
+    public void deletePost(Long postId) {
         Post post = findPostById(postId);
         postRepository.delete(post);
-        return postId;
     }
 
-    public List<PostResponse> getAllPostsByUser(User user) {
+    @Transactional(readOnly = true)
+    public List<PostResponse.PostInfo> getAllPostsByUser(User user) {
         List<Post> posts = postRepository.findAllByUserOrderByCreatedAtDesc(user);
         return postConverter.toResponseList(posts);
     }

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -31,21 +31,21 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostResponse.PostInfo getPost(Long postId) {
-        Post post = findPostById(postId);
+    public PostResponse.PostInfo getPost(User user, Long postId) {
+        Post post = findPostById(user, postId);
         return postConverter.toResponse(post);
     }
 
     @Transactional
-    public PostResponse.PostInfo updatePost(Long postId, PostRequest.PostCommand command) {
-        Post post = findPostById(postId);
+    public PostResponse.PostInfo updatePost(User user, Long postId, PostRequest.PostCommand command) {
+        Post post = findPostById(user, postId);
         post.update(command.getSite(), command.getLevel(), command.getTitle(), command.getContent());
         return postConverter.toResponse(post);
     }
 
     @Transactional
-    public void deletePost(Long postId) {
-        Post post = findPostById(postId);
+    public void deletePost(User user, Long postId) {
+        Post post = findPostById(user, postId);
         postRepository.delete(post);
     }
 
@@ -55,8 +55,12 @@ public class PostService {
         return postConverter.toResponseList(posts);
     }
 
-    private Post findPostById(Long postId) {
-        return postRepository.findById(postId)
+    private Post findPostById(User user, Long postId) {
+    	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    	if (!post.getUser().getId().equals(user.getId())) {
+    		throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
+    	}
+        return post;
     }
 }

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -50,7 +50,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponse.PostInfo> getAllPostsByUser(User user) {
+    public List<PostResponse.PosOverview> getAllPostsByUser(User user) {
         List<Post> posts = postRepository.findAllByUserOrderByCreatedAtDesc(user);
         return postConverter.toResponseList(posts);
     }


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #19 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
사용자별 포스트 목록 API 구현 및 리팩토링

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 로그인한 사용자가 작성한 전체 post 목록 가져오기 기능
- 전체목록 가져올 때의 response 지정 (포스트아이디, 사이트, 레벨, 제목)
- post response/request dto를 builder 패턴으로 변경
- post 읽어올 때 리턴 값 추가 (작성자, 생성/업데이트 시간)
- 다른 사용자 게시물 접근에 대한 권한 체크 추가

## 🧪 테스트 체크리스트
- [x] post CRUD 재확인
- [x] 로그인한 사용자가 작성한 전체 포스트 목록 읽어오기 기능 확인 
- [x] 다른 계정으로 로그인한 후 전체 포스트 목록 읽어오기 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
post response/request dto를 다른 코드와 패턴이 일치하도록 builder 사용하도록 겸사겸사 바꿨는데 이때문에 서비스랑 컨트롤러도 조금씩 변경돼서 번거롭겠지만 post CRUD 확인 한번만 더 부탁드려요!! 🙇‍♂️

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
