### PR TITLE
[#16] 이메일 인증 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     
     implementation 'org.postgresql:postgresql'
     implementation "io.jsonwebtoken:jjwt:0.12.3"
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 springBoot {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation "io.jsonwebtoken:jjwt:0.12.3"
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.sun.mail:jakarta.mail:2.0.1'
 }
 
 springBoot {

--- a/src/main/java/com/doyak/reflector/config/EmailConfig.java
+++ b/src/main/java/com/doyak/reflector/config/EmailConfig.java
@@ -27,19 +27,19 @@ public class EmailConfig {
 	private boolean auth;
 	
 	@Value("${spring.mail.properties.mail.smtp.starttls.enable}")
-	private String starttlsEnable;
+	private boolean starttlsEnable;
 	
 	@Value("${spring.mail.properties.mail.smtp.starttls.required}")
-	private String starttlsRequired;
+	private boolean starttlsRequired;
 	
 	@Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
-	private String connectionTimeout;
+	private int connectionTimeout;
 	
 	@Value("${spring.mail.properties.mail.smtp.timeout}")
-	private String timeout;
+	private int timeout;
 	
 	@Value("${spring.mail.properties.mail.smtp.writetimeout}")
-	private String writeTimeout;
+	private int writeTimeout;
 	
 	@Bean
 	public JavaMailSender javaMailSender() {
@@ -57,7 +57,7 @@ public class EmailConfig {
 	private Properties getMailProperties() {
 		Properties properties = new Properties();
 		properties.put("mail.smtp.auth", auth);
-		properties.put("mail.smtp.starttls.enalbe", starttlsEnable);
+		properties.put("mail.smtp.starttls.enable", starttlsEnable);
 		properties.put("mail.smtp.connectiontimeout", connectionTimeout);
 		properties.put("mail.smtp.timeout", timeout);
 		properties.put("mail.smtp.writetimeout", writeTimeout);

--- a/src/main/java/com/doyak/reflector/config/EmailConfig.java
+++ b/src/main/java/com/doyak/reflector/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package com.doyak.reflector.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+	
+	@Value("${spring.mail.host}")
+	private String host;
+	
+	@Value("${spring.mail.port}")
+	private int port;
+	
+	@Value("${spring.mail.username}")
+	private String username;
+	
+	@Value("${spring.mail.password}")
+	private String password;
+	
+	@Value("${spring.mail.properties.mail.smtp.auth}")
+	private boolean auth;
+	
+	@Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+	private String starttlsEnable;
+	
+	@Value("${spring.mail.properties.mail.smtp.starttls.required}")
+	private String starttlsRequired;
+	
+	@Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+	private String connectionTimeout;
+	
+	@Value("${spring.mail.properties.mail.smtp.timeout}")
+	private String timeout;
+	
+	@Value("${spring.mail.properties.mail.smtp.writetimeout}")
+	private String writeTimeout;
+	
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+		mailSender.setHost(host);
+		mailSender.setPort(port);
+		mailSender.setUsername(username);
+		mailSender.setPassword(password);
+		mailSender.setDefaultEncoding("UTF-8");
+		mailSender.setJavaMailProperties(getMailProperties());
+		
+		return mailSender;
+	}
+	
+	private Properties getMailProperties() {
+		Properties properties = new Properties();
+		properties.put("mail.smtp.auth", auth);
+		properties.put("mail.smtp.starttls.enalbe", starttlsEnable);
+		properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+		properties.put("mail.smtp.timeout", timeout);
+		properties.put("mail.smtp.writetimeout", writeTimeout);
+		
+		return properties;
+	}
+	
+}

--- a/src/main/java/com/doyak/reflector/config/RedisConfig.java
+++ b/src/main/java/com/doyak/reflector/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.doyak.reflector.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+	
+	@Value("${spring.data.redis.host}")
+	private String host;
+	
+	@Value("${spring.data.redis.port}")
+	private int port;
+	
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+	
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+		RedisTemplate<byte[], byte[]> redisTemplate =new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+	
+	
+}

--- a/src/main/java/com/doyak/reflector/config/SecurityConfig.java
+++ b/src/main/java/com/doyak/reflector/config/SecurityConfig.java
@@ -59,8 +59,7 @@ public class SecurityConfig {
                     .accessDeniedHandler(jwtAccessDeniedHandler))
             
 			.authorizeHttpRequests(auth -> auth
-					.requestMatchers("/api/users/sign-up").permitAll()
-                    .requestMatchers("/api/users/login").permitAll()
+					.requestMatchers("/api/users/*").permitAll()
                     .requestMatchers("/api/posts").permitAll()
                     .requestMatchers(AUTH_WHITELIST).permitAll()
 					.anyRequest().authenticated())

--- a/src/main/java/com/doyak/reflector/config/SecurityConfig.java
+++ b/src/main/java/com/doyak/reflector/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
             
 			.authorizeHttpRequests(auth -> auth
 					.requestMatchers("/api/users/*").permitAll()
+					.requestMatchers("/api/users/verification/email", "/api/users/verification/email/*").permitAll()
                     .requestMatchers("/api/posts").permitAll()
                     .requestMatchers(AUTH_WHITELIST).permitAll()
 					.anyRequest().authenticated())

--- a/src/main/java/com/doyak/reflector/config/SecurityConfig.java
+++ b/src/main/java/com/doyak/reflector/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
             
 			.authorizeHttpRequests(auth -> auth
 					.requestMatchers("/api/users/*").permitAll()
-					.requestMatchers("/api/users/verification/email", "/api/users/verification/email/*").permitAll()
+					.requestMatchers("/api/users/verification/**").permitAll()
                     .requestMatchers("/api/posts").permitAll()
                     .requestMatchers(AUTH_WHITELIST).permitAll()
 					.anyRequest().authenticated())

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -46,9 +46,9 @@ public class UserController {
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@GetMapping("/email-verify")
+	@PostMapping("/email-verify-code")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
-	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.EmailVerifyDTO request) {
+	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.doyak.reflector.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,14 +38,14 @@ public class UserController {
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@PostMapping("/email-verify")
+	@PostMapping("/verification/email")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.sendEmail(request);
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@PostMapping("/email-verify-code")
+	@PostMapping("/verification/email/verify")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.verifyEmailCode(request);

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.ApiResponse;
+import com.doyak.reflector.service.EmailService;
 import com.doyak.reflector.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 	
 	private final UserService userService;
+	
+	private final EmailService emailService;
 	
 	@PostMapping("/sign-up")
 	@Operation(summary = "회원가입", description = "회원가입에 사용할 이메일과 비밀번호를 입력해주세요.")
@@ -34,4 +37,12 @@ public class UserController {
 		UserResponse.UserLoginResponseDTO response = userService.login(request);
 		return ApiResponse.onSuccess(response);
 	}
+	
+	@PostMapping("/email-verify")
+	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
+	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+		UserResponse.EmailVerifyDTO response = emailService.sendEmail(request);
+		return ApiResponse.onSuccess(response);
+	}
+	
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -38,6 +38,13 @@ public class UserController {
 		return ApiResponse.onSuccess(response);
 	}
 	
+	@PostMapping("/emails")
+	@Operation(summary = "이메일 중복 확인", description = "회원가입 할 이메일을 입력해주세요.")
+	public ApiResponse<UserResponse.EmailVerifyDTO> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+		UserResponse.EmailVerifyDTO response = userService.checkEmail(request);
+		return ApiResponse.onSuccess(response);
+	}
+	
 	@PostMapping("/verification/email")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -41,22 +41,22 @@ public class UserController {
 	@PostMapping("/emails")
 	@Operation(summary = "이메일 중복 확인", description = "회원가입 할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
-		UserResponse.EmailVerifyDTO response = userService.checkEmail(request);
-		return ApiResponse.onSuccess(response);
+		userService.checkEmail(request);
+		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
-		UserResponse.EmailVerifyDTO response = emailService.sendEmail(request);
-		return ApiResponse.onSuccess(response);
+		emailService.sendEmail(request);
+		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails/verify")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
-		UserResponse.EmailVerifyDTO response = emailService.verifyEmailCode(request);
-		return ApiResponse.onSuccess(response);
+		emailService.verifyEmailCode(request);
+		return ApiResponse.onSuccess(null);
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -45,16 +45,16 @@ public class UserController {
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@PostMapping("/verification/email")
+	@PostMapping("/verification/emails")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.sendEmail(request);
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@PostMapping("/verification/email/verify")
+	@PostMapping("/verification/emails/verify")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
-	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
+	public ApiResponse<UserResponse.EmailVerifyDTO> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.doyak.reflector.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +43,13 @@ public class UserController {
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
 	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		UserResponse.EmailVerifyDTO response = emailService.sendEmail(request);
+		return ApiResponse.onSuccess(response);
+	}
+	
+	@GetMapping("/email-verify")
+	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
+	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.EmailVerifyDTO request) {
+		UserResponse.EmailVerifyDTO response = emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(response);
 	}
 	

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -40,21 +40,21 @@ public class UserController {
 	
 	@PostMapping("/emails")
 	@Operation(summary = "이메일 중복 확인", description = "회원가입 할 이메일을 입력해주세요.")
-	public ApiResponse<UserResponse.EmailVerifyDTO> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+	public ApiResponse<?> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		userService.checkEmail(request);
 		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
-	public ApiResponse<UserResponse.EmailVerifyDTO> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+	public ApiResponse<?> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		emailService.sendEmail(request);
 		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails/verify")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
-	public ApiResponse<UserResponse.EmailVerifyDTO> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
+	public ApiResponse<?> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(null);
 	}

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -20,9 +20,4 @@ public class UserConverter {
 				.build();
 	}
 	
-	public static UserResponse.EmailVerifyDTO toEmailVerifyResponse(Boolean status) {
-		return UserResponse.EmailVerifyDTO.builder()
-				.status(status)
-				.build();
-	}
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.converter;
 
-import java.util.UUID;
-
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.dto.request.UserRequest;
@@ -19,6 +17,12 @@ public class UserConverter {
 		return User.builder()
 				.email(userDto.getEmail())
 				.password(encodedPassword)
+				.build();
+	}
+	
+	public static UserResponse.EmailVerifyDTO toEmailVerifyResponse(Boolean status) {
+		return UserResponse.EmailVerifyDTO.builder()
+				.status(status)
 				.build();
 	}
 }

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -51,7 +51,7 @@ public class UserRequest {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter
-	public static class EmailVerifyDTO {
+	public static class EmailCodeDTO {
 		
 		@NotBlank(message = "이메일은 필수 입력 값입니다.")
 		String email;

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -47,4 +47,17 @@ public class UserRequest {
 		String email;
 	}
 	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class EmailVerifyDTO {
+		
+		@NotBlank(message = "이메일은 필수 입력 값입니다.")
+		String email;
+		
+		@Pattern(regexp = "^[0-9]{6}$", message = "인증 코드는 숫자 6자리여야 합니다.")
+		String code;
+	}
+	
 }

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -1,6 +1,7 @@
 package com.doyak.reflector.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,4 +36,15 @@ public class UserRequest {
 		@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
 		String password;
 	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class UserEmailDTO {
+		
+		@NotBlank(message = "이메일은 필수 입력 값입니다.")
+		String email;
+	}
+	
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -17,11 +17,4 @@ public class UserResponse {
 		String token;
 	}
 	
-	@Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    @Getter
-    public static class EmailVerifyDTO {
-		Boolean status;
-	}
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -16,4 +16,12 @@ public class UserResponse {
 		String email;
 		String token;
 	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class EmailVerifyDTO {
+		Boolean status;
+	}
 }

--- a/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
@@ -31,7 +31,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "존재하지 않는 유저입니다."),
     USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 유저입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4003", "비밀번호가 불일치 합니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER4003", "비밀번호가 불일치 합니다."),
+    INVALID_EMAIL(HttpStatus.NOT_FOUND, "USER4004", "인증번호를 확인할 수 없습니다. 이메일을 다시 확인하거나 인증번호를 새로 요청해주세요."),
+    INVALID_CODE(HttpStatus.BAD_REQUEST, "USER4005", "인증번호가 불일치 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/doyak/reflector/service/EmailService.java
+++ b/src/main/java/com/doyak/reflector/service/EmailService.java
@@ -1,0 +1,57 @@
+package com.doyak.reflector.service;
+
+import java.security.SecureRandom;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import com.doyak.reflector.converter.UserConverter;
+import com.doyak.reflector.dto.request.UserRequest;
+import com.doyak.reflector.dto.response.UserResponse;
+import com.doyak.reflector.util.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+	
+	private final JavaMailSender javaMailSender;
+	private final RedisUtil redisUtil;
+	private static final SecureRandom secureRandom = new SecureRandom();
+	private static final String senderEmail = "email";
+	
+	private String createCode() {
+		int num = secureRandom.nextInt(1_000_000);
+        return String.format("%06d", num);
+	}
+	
+	private SimpleMailMessage createEmailVerifyForm(String email) {
+		String code = createCode();
+		
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(email);  // 수신자
+		message.setSubject("[reflector] 인증번호를 확인해주세요.");  // 제
+		message.setText("[" + code + "]");  // 내용
+		message.setFrom(senderEmail);
+		
+		redisUtil.setDataExpire(email, code, 60 * 3L);
+		return message;
+	}
+	
+	public UserResponse.EmailVerifyDTO sendEmail(UserRequest.UserEmailDTO emailDTO) {
+		String email = emailDTO.getEmail();
+		if (redisUtil.existData(email)) {
+			redisUtil.deleteData(email);
+		}
+		
+		SimpleMailMessage message = createEmailVerifyForm(email);
+		javaMailSender.send(message);
+		
+		return UserConverter.toEmailVerifyResponse(true);
+	}
+	
+}

--- a/src/main/java/com/doyak/reflector/service/EmailService.java
+++ b/src/main/java/com/doyak/reflector/service/EmailService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import com.doyak.reflector.converter.UserConverter;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
+import com.doyak.reflector.payload.code.status.ErrorStatus;
+import com.doyak.reflector.payload.exception.handler.UserHandler;
 import com.doyak.reflector.util.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -36,9 +38,9 @@ public class EmailService {
 		String code = createCode();
 		
 		SimpleMailMessage message = new SimpleMailMessage();
-		message.setTo(email);  // 수신자
-		message.setSubject("[reflector] 인증번호를 확인해주세요.");  // 제
-		message.setText("[" + code + "]");  // 내용
+		message.setTo(email);
+		message.setSubject("[reflector] 인증번호를 확인해주세요.");
+		message.setText("[" + code + "]");
 		message.setFrom(senderEmail);
 		
 		redisUtil.setDataExpire(email, code, 60 * 3L);
@@ -50,7 +52,6 @@ public class EmailService {
 		if (redisUtil.existData(email)) {
 			redisUtil.deleteData(email);
 		}
-		System.out.println("Sender: " + senderEmail);
 		SimpleMailMessage message = createEmailVerifyForm(email);
 		javaMailSender.send(message);
 		
@@ -60,9 +61,12 @@ public class EmailService {
 	public UserResponse.EmailVerifyDTO verifyEmailCode(UserRequest.EmailCodeDTO emailVerifyDTO) {
 		String codeFoundByEmail = redisUtil.getData(emailVerifyDTO.getEmail());
 		if (codeFoundByEmail == null) {
-			return UserConverter.toEmailVerifyResponse(false);
+			throw new UserHandler(ErrorStatus.INVALID_EMAIL);
+		} else if (!codeFoundByEmail.equals(emailVerifyDTO.getCode())) {
+			throw new UserHandler(ErrorStatus.INVALID_CODE);
+		} else {
+			return UserConverter.toEmailVerifyResponse(true);
 		}
-		return UserConverter.toEmailVerifyResponse(codeFoundByEmail.equals(emailVerifyDTO.getCode()));
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/service/EmailService.java
+++ b/src/main/java/com/doyak/reflector/service/EmailService.java
@@ -54,4 +54,12 @@ public class EmailService {
 		return UserConverter.toEmailVerifyResponse(true);
 	}
 	
+	public UserResponse.EmailVerifyDTO verifyEmailCode(UserRequest.EmailVerifyDTO emailVerifyDTO) {
+		String codeFoundByEmail = redisUtil.getData(emailVerifyDTO.getEmail());
+		if (codeFoundByEmail == null) {
+			return UserConverter.toEmailVerifyResponse(false);
+		}
+		return UserConverter.toEmailVerifyResponse(codeFoundByEmail.equals(emailVerifyDTO.getCode()));
+	}
+	
 }

--- a/src/main/java/com/doyak/reflector/service/EmailService.java
+++ b/src/main/java/com/doyak/reflector/service/EmailService.java
@@ -2,6 +2,7 @@ package com.doyak.reflector.service;
 
 import java.security.SecureRandom;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,9 @@ public class EmailService {
 	private final JavaMailSender javaMailSender;
 	private final RedisUtil redisUtil;
 	private static final SecureRandom secureRandom = new SecureRandom();
-	private static final String senderEmail = "email";
+	
+	@Value("${spring.mail.username}")
+	private String senderEmail;
 	
 	private String createCode() {
 		int num = secureRandom.nextInt(1_000_000);
@@ -47,14 +50,14 @@ public class EmailService {
 		if (redisUtil.existData(email)) {
 			redisUtil.deleteData(email);
 		}
-		
+		System.out.println("Sender: " + senderEmail);
 		SimpleMailMessage message = createEmailVerifyForm(email);
 		javaMailSender.send(message);
 		
 		return UserConverter.toEmailVerifyResponse(true);
 	}
 	
-	public UserResponse.EmailVerifyDTO verifyEmailCode(UserRequest.EmailVerifyDTO emailVerifyDTO) {
+	public UserResponse.EmailVerifyDTO verifyEmailCode(UserRequest.EmailCodeDTO emailVerifyDTO) {
 		String codeFoundByEmail = redisUtil.getData(emailVerifyDTO.getEmail());
 		if (codeFoundByEmail == null) {
 			return UserConverter.toEmailVerifyResponse(false);

--- a/src/main/java/com/doyak/reflector/service/EmailService.java
+++ b/src/main/java/com/doyak/reflector/service/EmailService.java
@@ -6,10 +6,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.doyak.reflector.converter.UserConverter;
 import com.doyak.reflector.dto.request.UserRequest;
-import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.handler.UserHandler;
 import com.doyak.reflector.util.RedisUtil;
@@ -47,25 +46,23 @@ public class EmailService {
 		return message;
 	}
 	
-	public UserResponse.EmailVerifyDTO sendEmail(UserRequest.UserEmailDTO emailDTO) {
+	@Transactional
+	public void sendEmail(UserRequest.UserEmailDTO emailDTO) {
 		String email = emailDTO.getEmail();
 		if (redisUtil.existData(email)) {
 			redisUtil.deleteData(email);
 		}
 		SimpleMailMessage message = createEmailVerifyForm(email);
 		javaMailSender.send(message);
-		
-		return UserConverter.toEmailVerifyResponse(true);
 	}
 	
-	public UserResponse.EmailVerifyDTO verifyEmailCode(UserRequest.EmailCodeDTO emailVerifyDTO) {
+	@Transactional
+	public void verifyEmailCode(UserRequest.EmailCodeDTO emailVerifyDTO) {
 		String codeFoundByEmail = redisUtil.getData(emailVerifyDTO.getEmail());
 		if (codeFoundByEmail == null) {
 			throw new UserHandler(ErrorStatus.INVALID_EMAIL);
 		} else if (!codeFoundByEmail.equals(emailVerifyDTO.getCode())) {
 			throw new UserHandler(ErrorStatus.INVALID_CODE);
-		} else {
-			return UserConverter.toEmailVerifyResponse(true);
 		}
 	}
 	

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -24,10 +24,9 @@ public class UserService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     
-    public UserResponse.EmailVerifyDTO checkEmail(UserRequest.UserEmailDTO request) {
+    public void checkEmail(UserRequest.UserEmailDTO request) {
     	if (userRepository.findByEmail(request.getEmail()).isPresent())
     		throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
-    	return UserConverter.toEmailVerifyResponse(true);
     }
     
     @Transactional

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -24,6 +24,12 @@ public class UserService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     
+    public UserResponse.EmailVerifyDTO checkEmail(UserRequest.UserEmailDTO request) {
+    	if (userRepository.findByEmail(request.getEmail()).isPresent())
+    		throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
+    	return UserConverter.toEmailVerifyResponse(true);
+    }
+    
     @Transactional
     public UserResponse.UserLoginResponseDTO signup(UserRequest.UserSignUpDTO request) {
     	if (userRepository.findByEmail(request.getEmail()).isPresent())

--- a/src/main/java/com/doyak/reflector/util/RedisUtil.java
+++ b/src/main/java/com/doyak/reflector/util/RedisUtil.java
@@ -1,0 +1,35 @@
+package com.doyak.reflector.util;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+	
+	private final StringRedisTemplate template;
+	
+	public String getData(String key) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		return valueOperations.get(key);
+	}
+	
+	public Boolean existData(String key) {
+		return Boolean.TRUE.equals(template.hasKey(key));
+	}
+	
+	public void setDataExpire(String key, String value, long duration) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		Duration expireDuration = Duration.ofSeconds(duration);
+		valueOperations.set(key,  value, expireDuration);
+	}
+	
+	public void deleteData(String key) {
+		template.delete(key);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,25 @@ spring:
     redis:
       host: localhost
       port: 6379		
+  
+  # Mail
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_ADDRESS}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 180000
+        
 ---
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
   jwt:
     secret: ${JWT_SECRET:vDbxxvKpvBWxbhY2HTY0q+jo1lU/fVBwzn6N4iz+zOE=}
 
+  # Redis
+  data:
+    redis:
+      host: localhost
+      port: 6379		
 ---
 
 spring:
@@ -27,3 +32,4 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
회원가입 전 이메일 인증 관련 기능 구현

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 인증번호 캐싱을 위한 Redis 설정 및 유틸 추가
- `Javamailsender` 기반 인증번호 발송 기능 구현
- Redis 기반 인증번호 검증 기능 구현
- 이메일 중복 확인 기능 구현

## 🧪 테스트 체크리스트
- [x] `/api/users/emails` 호출 응답 & 예외 처리 확인
- [x] `/api/users/verification/emails` 호출 응답 & 예외 처리 확인
- [x] `/api/users/verification/emails/verify` 호출 응답 & 예외 처리 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 인증번호는 무작위 숫자 6자리이며, 인증번호 발급 만료시간은 3분으로 설정해두었습니다.
- 메일 전송을 위해 환경변수 설정이 필요합니다. 필요한 환경변수는 아래와 같습니다. 환경변수의 값은 노션 **🔐계정** 페이지를 참고해주세요!
```
    username: ${MAIL_ADDRESS}
    password: ${MAIL_PASSWORD}
``` 
- 현재 이메일 중복 확인 로직은 `userService` 단에, 이메일 발송 및 인증번호 확인 로직은 `emailService` 단에 두었습니다. 이메일 중복 확인은 이미 등록된 회원 데이터에 접근해야하고, 이메일 전송 및 인증번호 검증은 회원 가입 이전 단계의 단순 검증 로직에 해당한다고 생각하여 이와 같이 분리해두었습니다. 현재는 이 기준으로 분리했지만, 더 나은 방법이 있을지 고민됩니다!
- 이메일 중복 여부, 이메일 전송 여부, 인증번호 확인 여부 모두 응답으로 간단한 boolean 값만 리턴하도록 구현하였습니다. 추후 프론트엔드 작업을 고려했을 때 null을 보내는 것보다 명시적인 boolean 값이 나을 것 같아 해당 방향으로 구현했는데 응답으로 더 필요한 값이나 더 나은 방법이 있을까요?

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
