### PR TITLE
[#18] 회원 정보 수정 및 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -40,9 +40,9 @@ public class UserController {
 	}
 	
 	@PutMapping
-	@Operation(summary = "회원 정보 수정", description = "변경할 이메일/비밀번호를 입력해주세요.")
+	@Operation(summary = "회원 정보 수정", description = "변경할 이메일/비밀번호를 입력해주세요. 이메일 변경 시 재로그인이 필요합니다.")
 	public ApiResponse<UserResponse.UserUpdateDTO> update(@AuthenticationPrincipal User user, 
-														  @RequestBody UserRequest.UserUpdateDTO request) {
+														  @Valid @RequestBody UserRequest.UserUpdateDTO request) {
 		UserResponse.UserUpdateDTO response = userService.update(user, request);
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.doyak.reflector.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.ApiResponse;
@@ -32,6 +35,14 @@ public class UserController {
 	@Operation(summary = "로그인", description = "로그인할 유저의 이메일과 비밀번호를 입력해주세요.")
 	public ApiResponse<UserResponse.UserLoginResponseDTO> login(@Valid @RequestBody UserRequest.UserLoginDTO request) {
 		UserResponse.UserLoginResponseDTO response = userService.login(request);
+		return ApiResponse.onSuccess(response);
+	}
+	
+	@PutMapping("/users")
+	@Operation(summary = "회원 정보 수정", description = "변경할 이메일/비밀번호를 입력해주세요.")
+	public ApiResponse<UserResponse.UserUpdateDTO> update(@AuthenticationPrincipal User user, 
+														  @RequestBody UserRequest.UserUpdateDTO request) {
+		UserResponse.UserUpdateDTO response = userService.update(user, request);
 		return ApiResponse.onSuccess(response);
 	}
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
 	}
 	
 	@DeleteMapping
-	@Operation(summary = "회원 탈퇴", description = "비밀번호를 입력해주세요.")
+	@Operation(summary = "회원 탈퇴")
 	public ApiResponse<UserResponse.UserDeleteDTO> delete(@AuthenticationPrincipal User user) {
 		userService.delete(user);
 		return ApiResponse.onSuccess(null);

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.doyak.reflector.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,6 +44,13 @@ public class UserController {
 	public ApiResponse<UserResponse.UserUpdateDTO> update(@AuthenticationPrincipal User user, 
 														  @RequestBody UserRequest.UserUpdateDTO request) {
 		UserResponse.UserUpdateDTO response = userService.update(user, request);
+		return ApiResponse.onSuccess(response);
+	}
+	
+	@DeleteMapping
+	@Operation(summary = "회원 탈퇴", description = "비밀번호를 입력해주세요.")
+	public ApiResponse<UserResponse.UserDeleteDTO> delete(@AuthenticationPrincipal User user) {
+		UserResponse.UserDeleteDTO response = userService.delete(user);
 		return ApiResponse.onSuccess(response);
 	}
 

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -38,11 +38,12 @@ public class UserController {
 		return ApiResponse.onSuccess(response);
 	}
 	
-	@PutMapping("/users")
+	@PutMapping
 	@Operation(summary = "회원 정보 수정", description = "변경할 이메일/비밀번호를 입력해주세요.")
 	public ApiResponse<UserResponse.UserUpdateDTO> update(@AuthenticationPrincipal User user, 
 														  @RequestBody UserRequest.UserUpdateDTO request) {
 		UserResponse.UserUpdateDTO response = userService.update(user, request);
 		return ApiResponse.onSuccess(response);
 	}
+
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
 	
 	@DeleteMapping
 	@Operation(summary = "회원 탈퇴")
-	public ApiResponse<UserResponse.UserDeleteDTO> delete(@AuthenticationPrincipal User user) {
+	public ApiResponse<?> delete(@AuthenticationPrincipal User user) {
 		userService.delete(user);
 		return ApiResponse.onSuccess(null);
 	}

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -50,8 +50,8 @@ public class UserController {
 	@DeleteMapping
 	@Operation(summary = "회원 탈퇴", description = "비밀번호를 입력해주세요.")
 	public ApiResponse<UserResponse.UserDeleteDTO> delete(@AuthenticationPrincipal User user) {
-		UserResponse.UserDeleteDTO response = userService.delete(user);
-		return ApiResponse.onSuccess(response);
+		userService.delete(user);
+		return ApiResponse.onSuccess(null);
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -25,4 +25,10 @@ public class UserConverter {
 				.email(user.getEmail())
 				.build();
 	}
+	
+	public static UserResponse.UserDeleteDTO toDeleteResponse(User user) {
+		return UserResponse.UserDeleteDTO.builder()
+				.email(user.getEmail())
+				.build();
+	}
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -26,9 +26,4 @@ public class UserConverter {
 				.build();
 	}
 	
-	public static UserResponse.UserDeleteDTO toDeleteResponse(User user) {
-		return UserResponse.UserDeleteDTO.builder()
-				.email(user.getEmail())
-				.build();
-	}
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.converter;
 
-import java.util.UUID;
-
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.dto.request.UserRequest;
@@ -19,6 +17,12 @@ public class UserConverter {
 		return User.builder()
 				.email(userDto.getEmail())
 				.password(encodedPassword)
+				.build();
+	}
+	
+	public static UserResponse.UserUpdateDTO toUpdateResponse(User user) {
+		return UserResponse.UserUpdateDTO.builder()
+				.email(user.getEmail())
 				.build();
 	}
 }

--- a/src/main/java/com/doyak/reflector/domain/Post.java
+++ b/src/main/java/com/doyak/reflector/domain/Post.java
@@ -39,7 +39,7 @@ public class Post extends BaseEntity{
 	@Column(name = "post_id")
 	private Long postId;
 	
-	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 	

--- a/src/main/java/com/doyak/reflector/domain/Post.java
+++ b/src/main/java/com/doyak/reflector/domain/Post.java
@@ -2,7 +2,6 @@ package com.doyak.reflector.domain;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import com.doyak.reflector.domain.common.BaseEntity;
 import com.doyak.reflector.domain.enums.Site;
@@ -40,7 +39,7 @@ public class Post extends BaseEntity{
 	@Column(name = "post_id")
 	private Long postId;
 	
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 	

--- a/src/main/java/com/doyak/reflector/domain/User.java
+++ b/src/main/java/com/doyak/reflector/domain/User.java
@@ -1,6 +1,8 @@
 package com.doyak.reflector.domain;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.security.core.GrantedAuthority;
@@ -10,10 +12,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.doyak.reflector.domain.common.BaseEntity;
 import com.doyak.reflector.dto.request.UserRequest;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,6 +43,9 @@ public class User extends BaseEntity implements UserDetails {
 	
 	@NonNull
 	private String password;
+	
+	@OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
 	
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/doyak/reflector/domain/User.java
+++ b/src/main/java/com/doyak/reflector/domain/User.java
@@ -54,7 +54,7 @@ public class User extends BaseEntity implements UserDetails {
         if (user.getPassword() != null && !user.getPassword().isEmpty()) {
             this.password = passwordEncoder.encode(user.getPassword());
         }
-        if (user.getEmail() != null) {
+        if (user.getEmail() != null && !user.getEmail().isEmpty()) {
             this.email = user.getEmail();
         }
     }

--- a/src/main/java/com/doyak/reflector/domain/User.java
+++ b/src/main/java/com/doyak/reflector/domain/User.java
@@ -5,8 +5,10 @@ import java.util.UUID;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.doyak.reflector.domain.common.BaseEntity;
+import com.doyak.reflector.dto.request.UserRequest;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -46,6 +48,15 @@ public class User extends BaseEntity implements UserDetails {
 	@Override
     public String getUsername() {
         return this.email;
+    }
+	
+	public void updateUser(UserRequest.UserUpdateDTO user, PasswordEncoder passwordEncoder) {
+        if (user.getPassword() != null && !user.getPassword().isEmpty()) {
+            this.password = passwordEncoder.encode(user.getPassword());
+        }
+        if (user.getEmail() != null) {
+            this.email = user.getEmail();
+        }
     }
 	
 }

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -42,8 +42,10 @@ public class UserRequest {
 	@AllArgsConstructor
 	public static class UserUpdateDTO {
 		
+		@NotBlank(message = "이메일을 입력해주세요. 변경하지 않을 것이라면 기존의 이메일을 입력해주세요.")
 		String email;
 		
+		@NotBlank(message = "비밀번호를 입력해주세요. 변경하지 않을 것이라면 기존의 비밀번호를 입력해주세요.")
 		String password;
 	}
 	

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -35,4 +35,16 @@ public class UserRequest {
 		@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
 		String password;
 	}
+	
+	@Builder
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class UserUpdateDTO {
+		
+		String email;
+		
+		String password;
+	}
+	
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -24,4 +24,12 @@ public class UserResponse {
     public static class UserUpdateDTO {
 		String email;
 	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class UserDeleteDTO {
+		String email;
+	}
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -25,11 +25,4 @@ public class UserResponse {
 		String email;
 	}
 	
-	@Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    @Getter
-	public static class UserDeleteDTO {
-		String email;
-	}
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -16,4 +16,12 @@ public class UserResponse {
 		String email;
 		String token;
 	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class UserUpdateDTO {
+		String email;
+	}
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -15,7 +15,9 @@ import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.handler.UserHandler;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -67,11 +69,11 @@ public class UserService {
     }
     
     @Transactional
-    public UserResponse.UserDeleteDTO delete(User user) {
+    public void delete(User user) {
     	User findUser = userRepository.findByEmail(user.getEmail())
 				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     	
     	userRepository.delete(findUser);
-    	return UserConverter.toDeleteResponse(findUser);
+    	log.info("Successfully delete user: ", findUser.getEmail());
     }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -74,6 +74,6 @@ public class UserService {
 				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     	
     	userRepository.delete(findUser);
-    	log.info("Successfully delete user: ", findUser.getEmail());
+    	log.info("Successfully delete user");
     }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -58,7 +58,7 @@ public class UserService {
     	User findUser = userRepository.findByEmail(user.getEmail())
 				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     	
-    	if (userRepository.findByEmail(request.getEmail()).isPresent())
+    	if (!request.getEmail().equals(user.getEmail()) && userRepository.findByEmail(request.getEmail()).isPresent())
     		throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
     	
     	findUser.updateUser(request, passwordEncoder);

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -53,5 +53,16 @@ public class UserService {
 		return UserConverter.toLoginResponse(user, accessToken);
 	}
     
-
+    @Transactional
+    public UserResponse.UserUpdateDTO update(User user, UserRequest.UserUpdateDTO request) {
+    	User findUser = userRepository.findByEmail(user.getEmail())
+				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    	
+    	if (userRepository.findByEmail(request.getEmail()).isPresent())
+    		throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
+    	
+    	findUser.updateUser(request, passwordEncoder);
+    	
+    	return UserConverter.toUpdateResponse(findUser);
+    }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -65,4 +65,13 @@ public class UserService {
     	
     	return UserConverter.toUpdateResponse(findUser);
     }
+    
+    @Transactional
+    public UserResponse.UserDeleteDTO delete(User user) {
+    	User findUser = userRepository.findByEmail(user.getEmail())
+				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    	
+    	userRepository.delete(findUser);
+    	return UserConverter.toDeleteResponse(findUser);
+    }
 }


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
회원 이메일/비밀번호 변경 기능 및 탈퇴 기능 구현

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 회원 정보(이메일/비밀번호) 수정 기능 구현
- 회원 탈퇴 기능 구현

## 🧪 테스트 체크리스트
- [x] 로그인 후 `PUT /api/users` 호출로 회원 정보 변경 응답 확인 & 데이터베이스 업데이트 확인
- [x] 로그인 후 `DELETE /api/users` 호출로 회원 탈퇴 응답 확인 & 데이터베이스 업데이트 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 회원 정보 수정 시 이메일과 비밀번호 모두 request로 받습니다. 만약 변경하지 않고 싶은 필드가 있다면 기존의 회원 정보를 그대로 넣으면 됩니다! (swagger 문서 확인)
- 현재 회원 정보 수정 API 호출 시 이메일도 변경 가능하게 구현되어 있으나, 이메일 변경 시 토큰 재발급 필수로 재로그인이 필요하다는 이유로 지난 회의에서 우선 이메일 수정은 불가능하게 하기로 결정했기 때문에, 테스트 시 비밀번호 변경만 확인해주시면 될 것 같습니다!

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
