### PR TITLE
[#17] 블럭 CRUD 기능 구현

### DIFF
--- a/src/main/java/com/doyak/reflector/config/SecurityConfig.java
+++ b/src/main/java/com/doyak/reflector/config/SecurityConfig.java
@@ -61,8 +61,6 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 					.requestMatchers("/api/users/sign-up").permitAll()
                     .requestMatchers("/api/users/login").permitAll()
-                    .requestMatchers("/api/posts").permitAll()
-                    .requestMatchers("/api/blocks/**").permitAll()
                     .requestMatchers(AUTH_WHITELIST).permitAll()
 					.anyRequest().authenticated())
 			

--- a/src/main/java/com/doyak/reflector/config/SecurityConfig.java
+++ b/src/main/java/com/doyak/reflector/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
 					.requestMatchers("/api/users/sign-up").permitAll()
                     .requestMatchers("/api/users/login").permitAll()
                     .requestMatchers("/api/posts").permitAll()
+                    .requestMatchers("/api/blocks/**").permitAll()
                     .requestMatchers(AUTH_WHITELIST).permitAll()
 					.anyRequest().authenticated())
 			

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -28,40 +28,40 @@ public class BlockController {
 	
 	@PostMapping("/text")
 	@Operation(summary = "텍스트 블럭 생성", description = "텍스트 내용을 입력해주세요.")
-	public ApiResponse<BlockResponse> createTextBlock( @PathVariable Long postId,
+	public ApiResponse<BlockResponse> createTextBlock(@PathVariable("postId") Long postId,
 	        											@RequestBody BlockRequest.TextCommand request) {
 	    return ApiResponse.onSuccess(blockService.createBlock(request, postId));
 	}
 
 	@PostMapping("/code")
 	@Operation(summary = "코드 블럭 생성", description = "코드 내용을 입력해주세요.")
-	public ApiResponse<BlockResponse> createCodeBlock( @PathVariable Long postId,
+	public ApiResponse<BlockResponse> createCodeBlock(@PathVariable("postId") Long postId,
 	        											@RequestBody BlockRequest.CodeCommand request) {
 	    return ApiResponse.onSuccess(blockService.createBlock(request, postId));
 	}
 	
 	@GetMapping("/{blockId}")
 	@Operation(summary = "해당 블럭 읽기", description = "읽어오길 원하는 블럭 아이디를 입력해주세요.")
-    public ApiResponse<BlockResponse> getBlock(@PathVariable Long blockId) {
+    public ApiResponse<BlockResponse> getBlock(@PathVariable("blockId") Long blockId) {
         return ApiResponse.onSuccess(blockService.getBlock(blockId));
     }
 
     @GetMapping
 	@Operation(summary = "전체 블럭 읽기")
-    public ApiResponse<List<BlockResponse>> getBlocksByPost(@PathVariable Long postId) {
+    public ApiResponse<List<BlockResponse>> getBlocksByPost(@PathVariable("postId") Long postId) {
         return ApiResponse.onSuccess(blockService.getBlocksByPostId(postId));
     }
     
     @PutMapping("/text/{blockId}")
     @Operation(summary = "텍스트 블럭 수정", description = "수정할 텍스트 내용을 입력해주세요.")
-    public ApiResponse<BlockResponse> updateTextBlock(@PathVariable Long blockId,
+    public ApiResponse<BlockResponse> updateTextBlock(@PathVariable("blockId") Long blockId,
             											@RequestBody BlockRequest.TextCommand request) {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
     
     @PutMapping("/code/{blockId}")
     @Operation(summary = "코드 블럭 수정", description = "수정할 코드 내용을 입력해주세요.")
-    public ApiResponse<BlockResponse> updateCodeBlock(@PathVariable Long blockId,
+    public ApiResponse<BlockResponse> updateCodeBlock(@PathVariable("blockId") Long blockId,
     													@RequestBody BlockRequest.CodeCommand request) {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
@@ -69,7 +69,7 @@ public class BlockController {
 
     @DeleteMapping("{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
-    public void deleteBlock(@PathVariable Long blockId) {
+    public void deleteBlock(@PathVariable("blockId") Long blockId) {
         blockService.deleteBlock(blockId);
     }
 

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -42,7 +42,7 @@ public class BlockController {
 	
 	@GetMapping("/{blockId}")
 	@Operation(summary = "해당 블럭 읽기", description = "읽어오길 원하는 블럭 아이디를 입력해주세요.")
-    public ApiResponse<BlockResponse> getBlock(@PathVariable("blockId") Long blockId) {
+    public ApiResponse<BlockResponse> getBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
         return ApiResponse.onSuccess(blockService.getBlock(blockId));
     }
 
@@ -54,14 +54,14 @@ public class BlockController {
     
     @PutMapping("/text/{blockId}")
     @Operation(summary = "텍스트 블럭 수정", description = "수정할 텍스트 내용을 입력해주세요.")
-    public ApiResponse<BlockResponse> updateTextBlock(@PathVariable("blockId") Long blockId,
+    public ApiResponse<BlockResponse> updateTextBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId,
             											@RequestBody BlockRequest.TextCommand request) {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
     
     @PutMapping("/code/{blockId}")
     @Operation(summary = "코드 블럭 수정", description = "수정할 코드 내용을 입력해주세요.")
-    public ApiResponse<BlockResponse> updateCodeBlock(@PathVariable("blockId") Long blockId,
+    public ApiResponse<BlockResponse> updateCodeBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId,
     													@RequestBody BlockRequest.CodeCommand request) {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
@@ -69,7 +69,7 @@ public class BlockController {
 
     @DeleteMapping("{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
-    public void deleteBlock(@PathVariable("blockId") Long blockId) {
+    public void deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
         blockService.deleteBlock(blockId);
     }
 

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -1,0 +1,76 @@
+package com.doyak.reflector.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.doyak.reflector.dto.request.BlockRequest;
+import com.doyak.reflector.dto.response.BlockResponse;
+import com.doyak.reflector.payload.ApiResponse;
+import com.doyak.reflector.service.BlockService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/blocks/{postId}")
+@RequiredArgsConstructor
+public class BlockController {
+
+	private final BlockService blockService;
+	
+	@PostMapping("/text")
+	@Operation(summary = "텍스트 블럭 생성", description = "텍스트 내용을 입력해주세요.")
+	public ApiResponse<BlockResponse> createTextBlock( @PathVariable Long postId,
+	        											@RequestBody BlockRequest.TextCommand request) {
+	    return ApiResponse.onSuccess(blockService.createBlock(request, postId));
+	}
+
+	@PostMapping("/code")
+	@Operation(summary = "코드 블럭 생성", description = "코드 내용을 입력해주세요.")
+	public ApiResponse<BlockResponse> createCodeBlock( @PathVariable Long postId,
+	        											@RequestBody BlockRequest.CodeCommand request) {
+	    return ApiResponse.onSuccess(blockService.createBlock(request, postId));
+	}
+	
+	@GetMapping("/{blockId}")
+	@Operation(summary = "해당 블럭 읽기", description = "읽어오길 원하는 블럭 아이디를 입력해주세요.")
+    public ApiResponse<BlockResponse> getBlock(@PathVariable Long blockId) {
+        return ApiResponse.onSuccess(blockService.getBlock(blockId));
+    }
+
+    @GetMapping
+	@Operation(summary = "전체 블럭 읽기")
+    public ApiResponse<List<BlockResponse>> getBlocksByPost(@PathVariable Long postId) {
+        return ApiResponse.onSuccess(blockService.getBlocksByPostId(postId));
+    }
+    
+    @PutMapping("/text/{blockId}")
+    @Operation(summary = "텍스트 블럭 수정", description = "수정할 텍스트 내용을 입력해주세요.")
+    public ApiResponse<BlockResponse> updateTextBlock(@PathVariable Long blockId,
+            											@RequestBody BlockRequest.TextCommand request) {
+        return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
+    }
+    
+    @PutMapping("/code/{blockId}")
+    @Operation(summary = "코드 블럭 수정", description = "수정할 코드 내용을 입력해주세요.")
+    public ApiResponse<BlockResponse> updateCodeBlock(@PathVariable Long blockId,
+    													@RequestBody BlockRequest.CodeCommand request) {
+        return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
+    }
+
+
+    @DeleteMapping("{blockId}")
+	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
+    public void deleteBlock(@PathVariable Long blockId) {
+        blockService.deleteBlock(blockId);
+    }
+
+}

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -60,7 +60,6 @@ public class BlockConverter {
     private BlockResponse.Text toTextResponse(TextBlock block) {
         return BlockResponse.Text.builder()
                 .content(block.getContent())
-                .orderIndex(block.getOrderIndex())
                 .build();
     }
 

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -8,6 +8,7 @@ import com.doyak.reflector.domain.Block;
 import com.doyak.reflector.domain.CodeBlock;
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.TextBlock;
+import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.BlockRequest;
 import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
@@ -17,28 +18,30 @@ import com.doyak.reflector.payload.exception.GeneralException;
 public class BlockConverter {
 
     // Request → Entity
-    public Block toBlock(BlockRequest request, int orderIndex, Post post) {
+    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user) {
         if (request instanceof BlockRequest.TextCommand textReq) {
-            return toTextEntity(textReq, orderIndex, post);
+            return toTextEntity(textReq, orderIndex, post, user);
         } else if (request instanceof BlockRequest.CodeCommand codeReq) {
-            return toCodeEntity(codeReq, orderIndex, post);
+            return toCodeEntity(codeReq, orderIndex, post, user);
         } else {
             throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
         }
     }
 
-    private TextBlock toTextEntity(BlockRequest.TextCommand request, int orderIndex, Post post) {
+    private TextBlock toTextEntity(BlockRequest.TextCommand request, int orderIndex, Post post, User user) {
         return TextBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
+        		.user(user)
                 .content(request.getContent())
                 .build();
     }
 
-    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post) {
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user) {
         return CodeBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
+        		.user(user)
                 .content(request.getContent())
                 .language(request.getLanguage())
                 .performTime(request.getPerformTime())

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -1,0 +1,82 @@
+package com.doyak.reflector.converter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.doyak.reflector.domain.Block;
+import com.doyak.reflector.domain.CodeBlock;
+import com.doyak.reflector.domain.Post;
+import com.doyak.reflector.domain.TextBlock;
+import com.doyak.reflector.dto.request.BlockRequest;
+import com.doyak.reflector.dto.response.BlockResponse;
+import com.doyak.reflector.payload.code.status.ErrorStatus;
+import com.doyak.reflector.payload.exception.GeneralException;
+
+@Component
+public class BlockConverter {
+
+    // Request → Entity
+    public Block toBlock(BlockRequest request, int orderIndex, Post post) {
+        if (request instanceof BlockRequest.TextCommand textReq) {
+            return toTextEntity(textReq, orderIndex, post);
+        } else if (request instanceof BlockRequest.CodeCommand codeReq) {
+            return toCodeEntity(codeReq, orderIndex, post);
+        } else {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
+        }
+    }
+
+    private TextBlock toTextEntity(BlockRequest.TextCommand request, int orderIndex, Post post) {
+        return TextBlock.builder()
+        		.orderIndex(orderIndex)
+        		.post(post)
+                .content(request.getContent())
+                .build();
+    }
+
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post) {
+        return CodeBlock.builder()
+        		.orderIndex(orderIndex)
+        		.post(post)
+                .content(request.getContent())
+                .language(request.getLanguage())
+                .performTime(request.getPerformTime())
+                .performMem(request.getPerformMem())
+                .build();
+    }
+
+    // Entity → Response
+    public BlockResponse toResponse(Block block) {
+        if (block instanceof TextBlock textBlock) {
+            return toTextResponse(textBlock);
+        } else if (block instanceof CodeBlock codeBlock) {
+            return toCodeResponse(codeBlock);
+        } else {
+        	throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
+        }
+    }
+
+    private BlockResponse.Text toTextResponse(TextBlock block) {
+        return BlockResponse.Text.builder()
+                .content(block.getContent())
+                .orderIndex(block.getOrderIndex())
+                .build();
+    }
+
+    private BlockResponse.Code toCodeResponse(CodeBlock block) {
+        return BlockResponse.Code.builder()
+                .content(block.getContent())
+                .language(block.getLanguage())
+                .performTime(block.getPerformTime())
+                .performMem(block.getPerformMem())
+                .build();
+    }
+
+    // Entity List → Response List
+    public List<BlockResponse> toResponseList(List<Block> blocks) {
+        return blocks.stream()
+                     .map(this::toResponse)
+                     .toList();
+    }
+}

--- a/src/main/java/com/doyak/reflector/converter/PostConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/PostConverter.java
@@ -1,9 +1,7 @@
 package com.doyak.reflector.converter;
 
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/doyak/reflector/domain/Block.java
+++ b/src/main/java/com/doyak/reflector/domain/Block.java
@@ -39,5 +39,9 @@ public abstract class Block {
 	
 	@Enumerated(EnumType.STRING)
 	private BlockType type;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
 
 }

--- a/src/main/java/com/doyak/reflector/domain/Block.java
+++ b/src/main/java/com/doyak/reflector/domain/Block.java
@@ -1,6 +1,5 @@
 package com.doyak.reflector.domain;
 
-import com.doyak.reflector.domain.common.BaseEntity;
 import com.doyak.reflector.domain.enums.BlockType;
 
 import jakarta.persistence.Column;
@@ -11,11 +10,21 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public abstract class Block extends BaseEntity {
+@Inheritance(strategy = InheritanceType.JOINED)
+@SuperBuilder
+public abstract class Block {
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,10 +33,11 @@ public abstract class Block extends BaseEntity {
 	
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "post_id")
-	private Post post;
+	protected Post post;
 	
-	private Integer orderIndex;
+	protected Integer orderIndex;
 	
 	@Enumerated(EnumType.STRING)
 	private BlockType type;
+
 }

--- a/src/main/java/com/doyak/reflector/domain/CodeBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/CodeBlock.java
@@ -30,8 +30,8 @@ public class CodeBlock extends Block {
 	private double performMem;
 	
 	// 업데이트 
-	public void update(String newContent, Language language, double performTime, double performMem) {
-	    this.content = newContent;
+	public void update(String content, Language language, double performTime, double performMem) {
+	    this.content = content;
 	    this.language = language;
 	    this.performTime = performTime;
 	    this.performMem = performMem;

--- a/src/main/java/com/doyak/reflector/domain/CodeBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/CodeBlock.java
@@ -28,4 +28,12 @@ public class CodeBlock extends Block {
 	
 	private double performTime;
 	private double performMem;
+	
+	// 업데이트 
+	public void update(String newContent, Language language, double performTime, double performMem) {
+	    this.content = newContent;
+	    this.language = language;
+	    this.performTime = performTime;
+	    this.performMem = performMem;
+	}
 }

--- a/src/main/java/com/doyak/reflector/domain/CodeBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/CodeBlock.java
@@ -1,0 +1,31 @@
+package com.doyak.reflector.domain;
+
+import com.doyak.reflector.domain.enums.Language;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+public class CodeBlock extends Block {
+	
+	@Lob
+	private String content;
+	
+	@Enumerated(EnumType.STRING)
+	private Language language;
+	
+	private double performTime;
+	private double performMem;
+}

--- a/src/main/java/com/doyak/reflector/domain/TextBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/TextBlock.java
@@ -1,0 +1,20 @@
+package com.doyak.reflector.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+public class TextBlock extends Block{
+	
+	@Lob
+	private String content;
+}

--- a/src/main/java/com/doyak/reflector/domain/TextBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/TextBlock.java
@@ -19,7 +19,7 @@ public class TextBlock extends Block{
 	private String content;
 	
 	// 업데이트  
-	public void update(String newContent) {
+	public void update(String content) {
 		this.content = content == null ? "" : content;
 	}
 }

--- a/src/main/java/com/doyak/reflector/domain/TextBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/TextBlock.java
@@ -17,4 +17,9 @@ public class TextBlock extends Block{
 	
 	@Lob
 	private String content;
+	
+	// 업데이트  
+	public void update(String newContent) {
+		this.content = content == null ? "" : content;
+	}
 }

--- a/src/main/java/com/doyak/reflector/domain/enums/Language.java
+++ b/src/main/java/com/doyak/reflector/domain/enums/Language.java
@@ -1,0 +1,5 @@
+package com.doyak.reflector.domain.enums;
+
+public enum Language {
+    JAVA, PYTHON, C, JS
+}

--- a/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
@@ -1,0 +1,22 @@
+package com.doyak.reflector.dto.request;
+
+import com.doyak.reflector.domain.enums.Language;
+
+import lombok.Getter;
+
+public interface BlockRequest {
+
+	@Getter
+	public class TextCommand implements BlockRequest {
+		private String content;
+	}
+	
+	@Getter
+	public class CodeCommand implements BlockRequest {
+		private String content;
+		private Language language;
+		private double performTime;
+		private double performMem;
+	}
+
+}

--- a/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
@@ -16,7 +16,6 @@ public interface BlockResponse {
     @Getter
 	public class Text implements BlockResponse {
         private String content;
-        private Integer orderIndex;
     }
 	
 	@Builder

--- a/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
@@ -1,0 +1,33 @@
+package com.doyak.reflector.dto.response;
+
+import com.doyak.reflector.domain.enums.Language;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public interface BlockResponse {
+    
+	@Builder
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public class Text implements BlockResponse {
+        private String content;
+        private Integer orderIndex;
+    }
+	
+	@Builder
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public class Code implements BlockResponse {
+        private String content;
+        private Language language;
+        private double performTime;
+        private double performMem;
+    }
+    
+}

--- a/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/doyak/reflector/payload/code/status/ErrorStatus.java
@@ -18,9 +18,13 @@ public enum ErrorStatus implements BaseErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 	
-    // Post
+    // Post 에러 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "게시글을 찾을 수 없습니다."),
     POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST4002", "다른 사용자의 게시글입니다."),
+    
+    // Block 에러 
+    BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK4001", "블럭을 찾을 수 없습니다."),
+    UNSUPPORTED_BLOCK_TYPE(HttpStatus.BAD_REQUEST, "BLOCK4002", "지원하지 않는 블럭타입입니다."),
 
 	// JWT 토큰 관련 에러 
 	NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/doyak/reflector/repository/BlockRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/BlockRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,6 +20,12 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
 	@Query("SELECT MAX(b.orderIndex) FROM Block b WHERE b.post = :post")
 	Optional<Integer> findMaxOrderIndexByPost(@Param("post") Post post);
+
+	@Modifying
+    @Query("UPDATE Block b SET b.orderIndex = b.orderIndex - 1 " +
+           "WHERE b.post.id = :postId AND b.orderIndex > :deletedOrderIndex")
+    void decrementOrderIndexAfter(@Param("postId") Long postId,
+                                  @Param("deletedOrderIndex") int deletedOrderIndex);
 
 
 }

--- a/src/main/java/com/doyak/reflector/repository/BlockRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/BlockRepository.java
@@ -1,0 +1,24 @@
+package com.doyak.reflector.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.doyak.reflector.domain.Block;
+import com.doyak.reflector.domain.Post;
+
+@Repository
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+	@Query("SELECT b FROM Block b WHERE b.post.id = :postId ORDER BY b.orderIndex")
+	List<Block> findAllByPostIdOrderByOrderIndex(@Param("postId") Long postId);
+
+	@Query("SELECT MAX(b.orderIndex) FROM Block b WHERE b.post = :post")
+	Optional<Integer> findMaxOrderIndexByPost(@Param("post") Post post);
+
+
+}

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -1,0 +1,91 @@
+package com.doyak.reflector.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.doyak.reflector.converter.BlockConverter;
+import com.doyak.reflector.domain.Block;
+import com.doyak.reflector.domain.CodeBlock;
+import com.doyak.reflector.domain.Post;
+import com.doyak.reflector.domain.TextBlock;
+import com.doyak.reflector.dto.request.BlockRequest;
+import com.doyak.reflector.dto.response.BlockResponse;
+import com.doyak.reflector.payload.code.status.ErrorStatus;
+import com.doyak.reflector.payload.exception.GeneralException;
+import com.doyak.reflector.repository.BlockRepository;
+import com.doyak.reflector.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+	private final PostRepository postRepository;
+    private final BlockRepository blockRepository;
+    private final BlockConverter blockConverter; 
+
+    // 코드 블럭 생성  
+    @Transactional
+    public BlockResponse createBlock(BlockRequest request, Long postId) {
+    	Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + 1;
+    	Block block = blockConverter.toBlock(request, nextOrderIndex, post);
+    	Block saved = blockRepository.save(block);
+    	return blockConverter.toResponse(saved);
+    }
+    
+    // 단일 블럭 조회 
+    @Transactional(readOnly = true)
+    public BlockResponse getBlock(Long blockId) {
+        Block block = findBlockById(blockId);
+        return blockConverter.toResponse(block);
+    }
+
+    // 게시글에 속한 블럭 목록 조회 
+    @Transactional(readOnly = true)
+    public List<BlockResponse> getBlocksByPostId(Long postId) {
+        List<Block> blocks = blockRepository.findAllByPostIdOrderByOrderIndex(postId);
+        return blockConverter.toResponseList(blocks);
+    }
+    
+    // 블럭 수정
+    @Transactional
+    public BlockResponse updateBlock(Long blockId, BlockRequest request) {
+        Block block = findBlockById(blockId);
+
+        if (request instanceof BlockRequest.TextCommand textRequest && block instanceof TextBlock textBlock) {
+            updateTextBlock(textBlock, textRequest);
+            return blockConverter.toResponse(textBlock);
+        } else if (request instanceof BlockRequest.CodeCommand codeRequest && block instanceof CodeBlock codeBlock) {
+            updateCodeBlock(codeBlock, codeRequest);
+            return blockConverter.toResponse(codeBlock);
+        } else {
+        	throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
+        }
+    }
+
+    private void updateTextBlock(TextBlock block, BlockRequest.TextCommand request) {
+    	block.update(request.getContent());
+    }
+
+    private void updateCodeBlock(CodeBlock block, BlockRequest.CodeCommand request) {
+        block.update(request.getContent(), request.getLanguage(), request.getPerformTime(), request.getPerformMem());
+    }
+
+
+    // 블럭 삭제 
+    @Transactional
+    public void deleteBlock(Long blockId) {
+        blockRepository.deleteById(blockId);
+    }
+    
+    private Block findBlockById(Long blockId) {
+    	Block block = blockRepository.findById(blockId)
+    		    .orElseThrow(() -> new GeneralException(ErrorStatus.BLOCK_NOT_FOUND));
+    	return block;
+    }
+}

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -33,7 +33,7 @@ public class BlockService {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + 1;
-    	Block block = blockConverter.toBlock(request, nextOrderIndex, post);
+    	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
     }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -72,7 +72,14 @@ public class BlockService {
     // 블럭 삭제 
     @Transactional
     public void deleteBlock(Long blockId) {
-        blockRepository.deleteById(blockId);
+        Block block = blockRepository.findById(blockId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE));
+
+        int deletedOrderIndex = block.getOrderIndex();
+        Long postId = block.getPost().getPostId();
+
+        blockRepository.delete(block);
+        blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
     }
     
     private Block findBlockById(Long blockId) {

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -58,22 +58,14 @@ public class BlockService {
         Block block = findBlockById(blockId);
 
         if (request instanceof BlockRequest.TextCommand textRequest && block instanceof TextBlock textBlock) {
-            updateTextBlock(textBlock, textRequest);
+            textBlock.update(textRequest.getContent());
             return blockConverter.toResponse(textBlock);
         } else if (request instanceof BlockRequest.CodeCommand codeRequest && block instanceof CodeBlock codeBlock) {
-            updateCodeBlock(codeBlock, codeRequest);
+        	codeBlock.update(codeRequest.getContent(), codeRequest.getLanguage(), codeRequest.getPerformTime(), codeRequest.getPerformMem());
             return blockConverter.toResponse(codeBlock);
         } else {
         	throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
         }
-    }
-
-    private void updateTextBlock(TextBlock block, BlockRequest.TextCommand request) {
-    	block.update(request.getContent());
-    }
-
-    private void updateCodeBlock(CodeBlock block, BlockRequest.CodeCommand request) {
-        block.update(request.getContent(), request.getLanguage(), request.getPerformTime(), request.getPerformMem());
     }
 
 

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -45,8 +45,7 @@ public class PostService {
 
     @Transactional
     public void deletePost(User user, Long postId) {
-        Post post = findPostById(user, postId);
-        postRepository.delete(post);
+        postRepository.deleteById(postId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #17 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
Block CRUD 구현 및 관련 리팩토링 

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 텍스/코드 블럭 생성, 수정, 조회, 삭제 기능 구현
- 블럭 삭제 시 이후 블럭들의 orderIndex 자동 감소
- post 삭제 로직 개선 (중복 select 제거)

## 🧪 테스트 체크리스트
- [x] 텍스트 블럭 생성, 조회, 수정, 삭제 정상 동작 확인
- [x] 코드 블럭 생성, 조회, 수정, 삭제 정상 동작 확인
- [x] 전체 블럭 읽기 API 정상 동작 확인
- [x] 특정 블럭 읽기 API 정상 동작 확인
- [x] 블럭 삭제 시 이후 블럭 orderIndex 자동 감소 확인 

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
block response에는 담긴 내용만 들어가면 될 것 같아서 order index가 안보여서 번거로우시겠지만 데이터베이스로 확인해주세요! 

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
