### PR TITLE
[#28] 포스트 응답 변경

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -69,8 +69,9 @@ public class BlockController {
 
     @DeleteMapping("{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
-    public void deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
+    public ApiResponse<Void> deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
         blockService.deleteBlock(blockId);
+        return ApiResponse.onSuccess(null);
     }
 
 }

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -45,12 +45,6 @@ public class BlockController {
     public ApiResponse<BlockResponse> getBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
         return ApiResponse.onSuccess(blockService.getBlock(blockId));
     }
-
-    @GetMapping
-	@Operation(summary = "전체 블럭 읽기")
-    public ApiResponse<List<BlockResponse>> getBlocksByPost(@PathVariable("postId") Long postId) {
-        return ApiResponse.onSuccess(blockService.getBlocksByPostId(postId));
-    }
     
     @PutMapping("/text/{blockId}")
     @Operation(summary = "텍스트 블럭 수정", description = "수정할 텍스트 내용을 입력해주세요.")

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
 	
 	@DeleteMapping
 	@Operation(summary = "회원 탈퇴")
-	public ApiResponse<?> delete(@AuthenticationPrincipal User user) {
+	public ApiResponse<Void> delete(@AuthenticationPrincipal User user) {
 		userService.delete(user);
 		return ApiResponse.onSuccess(null);
 	}

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -59,21 +59,21 @@ public class UserController {
 
 	@PostMapping("/emails")
 	@Operation(summary = "이메일 중복 확인", description = "회원가입 할 이메일을 입력해주세요.")
-	public ApiResponse<?> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+	public ApiResponse<Void> checkEmail(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		userService.checkEmail(request);
 		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails")
 	@Operation(summary = "이메일 인증번호 발송", description = "인증번호를 발송할 이메일을 입력해주세요.")
-	public ApiResponse<?> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
+	public ApiResponse<Void> sendCode(@Valid @RequestBody UserRequest.UserEmailDTO request) {
 		emailService.sendEmail(request);
 		return ApiResponse.onSuccess(null);
 	}
 	
 	@PostMapping("/verification/emails/verify")
 	@Operation(summary = "이메일 인증번호 코드 인증", description = "인증번호를 입력해주세요.")
-	public ApiResponse<?> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
+	public ApiResponse<Void> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(null);
 	}

--- a/src/main/java/com/doyak/reflector/converter/PostConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/PostConverter.java
@@ -4,15 +4,22 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.PostRequest;
+import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.dto.response.PostResponse;
 
 @Component
 public class PostConverter {
+	
+	@Autowired
+	private BlockConverter blockConverter;
+	
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     // 생성
     public Post toEntity(PostRequest.PostCommand command, User user) {
@@ -24,10 +31,12 @@ public class PostConverter {
         		.user(user)
         		.build();
     }
-
+    
     // 단일 
     public PostResponse.PostInfo toResponse(Post post) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    	List<BlockResponse> blockResponses = post.getBlocks() == null 
+    	        ? List.of() 
+    	        : blockConverter.toResponseList(post.getBlocks());
         return PostResponse.PostInfo.builder()
         			.postId(post.getPostId())
         			.site(post.getSite())
@@ -35,8 +44,9 @@ public class PostConverter {
         			.title(post.getTitle())
         			.content(post.getContent())
         			.author(post.getUser().getEmail())
-        			.createdAt(post.getCreatedAt().format(formatter))
-        			.updatedAt(post.getUpdatedAt().format(formatter))
+        			.createdAt(post.getCreatedAt().format(FORMATTER))
+        			.updatedAt(post.getUpdatedAt().format(FORMATTER))
+        			.blocks(blockResponses)
         			.build();
     }
 

--- a/src/main/java/com/doyak/reflector/domain/Post.java
+++ b/src/main/java/com/doyak/reflector/domain/Post.java
@@ -19,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -53,6 +54,7 @@ public class Post extends BaseEntity{
 	private String content;
 	
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("orderIndex ASC")
 	private List<Block> blocks = new ArrayList<>();
 
 	// 업데이트 

--- a/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/PostResponse.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.dto.response;
 
+import java.util.List;
+
 import com.doyak.reflector.domain.enums.Site;
 
 import lombok.AccessLevel;
@@ -23,6 +25,7 @@ public class PostResponse {
 		private String author;
 		private String createdAt;
 	    private String updatedAt;
+	    private List<BlockResponse> blocks;
 	}
 	
 	@Builder

--- a/src/main/java/com/doyak/reflector/repository/PostRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.doyak.reflector.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.doyak.reflector.domain.Post;
@@ -11,4 +14,7 @@ import com.doyak.reflector.domain.User;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUserOrderByCreatedAtDesc(User user); 
+    
+    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.blocks WHERE p.postId = :postId")
+    Optional<Post> findByIdWithBlocks(@Param("postId") Long postId);
 }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -45,13 +45,6 @@ public class BlockService {
         return blockConverter.toResponse(block);
     }
 
-    // 게시글에 속한 블럭 목록 조회 
-    @Transactional(readOnly = true)
-    public List<BlockResponse> getBlocksByPostId(Long postId) {
-        List<Block> blocks = blockRepository.findAllByPostIdOrderByOrderIndex(postId);
-        return blockConverter.toResponseList(blocks);
-    }
-    
     // 블럭 수정
     @Transactional
     public BlockResponse updateBlock(Long blockId, BlockRequest request) {

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -32,7 +32,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostResponse.PostInfo getPost(User user, Long postId) {
-        Post post = findPostById(user, postId);
+        Post post = findPostWithBlocks(user, postId);
         return postConverter.toResponse(post);
     }
 
@@ -57,6 +57,15 @@ public class PostService {
     private Post findPostById(User user, Long postId) {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+    	if (!post.getUser().getId().equals(user.getId())) {
+    		throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
+    	}
+        return post;
+    }
+   
+    private Post findPostWithBlocks(User user, Long postId) {
+    	Post post = postRepository.findByIdWithBlocks(postId)
+    			.orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     	if (!post.getUser().getId().equals(user.getId())) {
     		throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
     	}


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #28 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
특정 포스트 조회 시 블럭 내용도 함께 리턴하도록 수정 및 관련 함수 리팩토링

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 포스트 리턴 시 블럭 내용 리턴
- post, block, user 컨트롤러에서 삭제 메서드 부분 응답 통일화

## 🧪 테스트 체크리스트
- [x] 특정 포스트 조회 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- Block Service/Controller에서 특정 포스트에 속한 모든 block을 가져오는 부분이 필요없을 것으로 판단되어 제거 (post에서 불러옴)
- Post 조회 시 연관된 Block 리스트를 가져오기 위해 PostRepository에 findByIdWithBlocks 추가 사유
: 기본 findById는 Post만 가져옴. blocks는 LAZY 로딩(연관관계라서)해서 해당 컬렉션은 포함되지 않음
- 리턴할 때 넘길 데이터 없는 메서드들 리턴타입 ApiResponse<Void>로 통일
- PostConverter의 toResponse에서 formmater는 매번 새로 만들 필요가 없는 객체라 메서드 밖으로 뺌


## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
