### PR TITLE
[#25] 블럭 순서 변경 기능 구현

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -2,6 +2,7 @@ package com.doyak.reflector.controller;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -58,10 +59,17 @@ public class BlockController {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
 
-    @DeleteMapping("{blockId}")
+    @DeleteMapping("/{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
     public ApiResponse<Void> deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
         blockService.deleteBlock(postId, blockId);
+        return ApiResponse.onSuccess(null);
+    }
+    
+    @PatchMapping("/{blockId}")
+    @Operation(summary = "블럭 순서 변경", description = "순서 변경을 원하는 블럭 정보와 원하는 위치 인덱스를 입력해주세요.")
+    public ApiResponse<Void> reorderBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId, BlockRequest.ReorderBlock request) {
+        blockService.reorderBlock(postId, blockId, request);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -68,7 +68,8 @@ public class BlockController {
     
     @PatchMapping("/{blockId}")
     @Operation(summary = "블럭 순서 변경", description = "순서 변경을 원하는 블럭 정보와 원하는 위치 인덱스를 입력해주세요.")
-    public ApiResponse<Void> reorderBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId, BlockRequest.ReorderBlock request) {
+    public ApiResponse<Void> reorderBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId, 
+    									  @RequestBody BlockRequest.ReorderBlock request) {
         blockService.reorderBlock(postId, blockId, request);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.controller;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -64,7 +62,7 @@ public class BlockController {
     @DeleteMapping("{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
     public ApiResponse<Void> deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {
-        blockService.deleteBlock(blockId);
+        blockService.deleteBlock(postId, blockId);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -68,10 +70,10 @@ public class BlockController {
     
     @PatchMapping("/{blockId}")
     @Operation(summary = "블럭 순서 변경", description = "순서 변경을 원하는 블럭 정보와 원하는 위치 인덱스를 입력해주세요.")
-    public ApiResponse<Void> reorderBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId, 
+    public ApiResponse<List<BlockResponse>> reorderBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId, 
     									  @RequestBody BlockRequest.ReorderBlock request) {
-        blockService.reorderBlock(postId, blockId, request);
-        return ApiResponse.onSuccess(null);
+    	List<BlockResponse> response = blockService.reorderBlock(postId, blockId, request);
+        return ApiResponse.onSuccess(response);
     }
 
 }

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -58,7 +58,6 @@ public class BlockController {
         return ApiResponse.onSuccess(blockService.updateBlock(blockId, request));
     }
 
-
     @DeleteMapping("{blockId}")
 	@Operation(summary = "해당 블럭 삭제", description = "삭제하길 원하는 블럭 아이디를 입력해주세요.")
     public ApiResponse<Void> deleteBlock(@PathVariable("postId") Long postId, @PathVariable("blockId") Long blockId) {

--- a/src/main/java/com/doyak/reflector/controller/BlockController.java
+++ b/src/main/java/com/doyak/reflector/controller/BlockController.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.controller;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -19,6 +17,8 @@ import com.doyak.reflector.service.BlockService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("api/blocks/{postId}")

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -19,7 +19,7 @@ import com.doyak.reflector.payload.exception.GeneralException;
 public class BlockConverter {
 
     // Request → Entity
-    public Block toBlock(BlockCommand request, double orderIndex, Post post, User user) {
+    public Block toBlock(BlockCommand request, Double orderIndex, Post post, User user) {
         if (request instanceof BlockRequest.TextCommand textReq) {
             return toTextEntity(textReq, orderIndex, post, user);
         } else if (request instanceof BlockRequest.CodeCommand codeReq) {
@@ -29,7 +29,7 @@ public class BlockConverter {
         }
     }
 
-    private TextBlock toTextEntity(BlockRequest.TextCommand request, double orderIndex, Post post, User user) {
+    private TextBlock toTextEntity(BlockRequest.TextCommand request, Double orderIndex, Post post, User user) {
         return TextBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
@@ -38,7 +38,7 @@ public class BlockConverter {
                 .build();
     }
 
-    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, double orderIndex, Post post, User user) {
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, Double orderIndex, Post post, User user) {
         return CodeBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -10,6 +10,7 @@ import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.TextBlock;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.BlockRequest;
+import com.doyak.reflector.dto.request.BlockRequest.BlockCommand;
 import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
@@ -18,7 +19,7 @@ import com.doyak.reflector.payload.exception.GeneralException;
 public class BlockConverter {
 
     // Request → Entity
-    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user) {
+    public Block toBlock(BlockCommand request, double orderIndex, Post post, User user) {
         if (request instanceof BlockRequest.TextCommand textReq) {
             return toTextEntity(textReq, orderIndex, post, user);
         } else if (request instanceof BlockRequest.CodeCommand codeReq) {
@@ -28,7 +29,7 @@ public class BlockConverter {
         }
     }
 
-    private TextBlock toTextEntity(BlockRequest.TextCommand request, int orderIndex, Post post, User user) {
+    private TextBlock toTextEntity(BlockRequest.TextCommand request, double orderIndex, Post post, User user) {
         return TextBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
@@ -37,7 +38,7 @@ public class BlockConverter {
                 .build();
     }
 
-    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user) {
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, double orderIndex, Post post, User user) {
         return CodeBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)

--- a/src/main/java/com/doyak/reflector/domain/Block.java
+++ b/src/main/java/com/doyak/reflector/domain/Block.java
@@ -35,7 +35,7 @@ public abstract class Block {
 	@JoinColumn(name = "post_id")
 	protected Post post;
 	
-	protected Integer orderIndex;
+	protected Double orderIndex;
 	
 	@Enumerated(EnumType.STRING)
 	private BlockType type;
@@ -43,5 +43,9 @@ public abstract class Block {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
+	
+	public void moveTo(Double newIndex) {
+        this.orderIndex = newIndex;
+    }
 
 }

--- a/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
@@ -36,8 +36,7 @@ public class BlockRequest {
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor
 	public static class ReorderBlock {
-		private Long blockId;
-		private Double newIndex;
+		private Integer newIndex;
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
@@ -2,21 +2,42 @@ package com.doyak.reflector.dto.request;
 
 import com.doyak.reflector.domain.enums.Language;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public interface BlockRequest {
+public class BlockRequest {
+	
+	public interface BlockCommand {} 
 
+	@Builder
 	@Getter
-	public class TextCommand implements BlockRequest {
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class TextCommand implements BlockCommand {
 		private String content;
 	}
 	
+	@Builder
 	@Getter
-	public class CodeCommand implements BlockRequest {
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class CodeCommand implements BlockCommand {
 		private String content;
 		private Language language;
 		private double performTime;
 		private double performMem;
+	}
+	
+	@Builder
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	public static class ReorderBlock {
+		private Long blockId;
+		private Double newIndex;
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/payload/exception/handler/BlockHandler.java
+++ b/src/main/java/com/doyak/reflector/payload/exception/handler/BlockHandler.java
@@ -1,0 +1,11 @@
+package com.doyak.reflector.payload.exception.handler;
+
+import com.doyak.reflector.payload.code.BaseErrorCode;
+import com.doyak.reflector.payload.exception.GeneralException;
+
+public class BlockHandler extends GeneralException {
+
+    public BlockHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/doyak/reflector/payload/exception/handler/PostHandler.java
+++ b/src/main/java/com/doyak/reflector/payload/exception/handler/PostHandler.java
@@ -1,0 +1,11 @@
+package com.doyak.reflector.payload.exception.handler;
+
+import com.doyak.reflector.payload.code.BaseErrorCode;
+import com.doyak.reflector.payload.exception.GeneralException;
+
+public class PostHandler extends GeneralException {
+
+    public PostHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/doyak/reflector/repository/BlockRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/BlockRepository.java
@@ -25,7 +25,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     @Query("UPDATE Block b SET b.orderIndex = b.orderIndex - 1 " +
            "WHERE b.post.id = :postId AND b.orderIndex > :deletedOrderIndex")
     void decrementOrderIndexAfter(@Param("postId") Long postId,
-                                  @Param("deletedOrderIndex") int deletedOrderIndex);
-
-
+                                  @Param("deletedOrderIndex") Double deletedOrderIndex);
+	
+	List<Block> findAllByPostOrderByOrderIndexAsc(Post post);
 }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -14,6 +14,8 @@ import com.doyak.reflector.dto.request.BlockRequest;
 import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
+import com.doyak.reflector.payload.exception.handler.BlockHandler;
+import com.doyak.reflector.payload.exception.handler.PostHandler;
 import com.doyak.reflector.repository.BlockRepository;
 import com.doyak.reflector.repository.PostRepository;
 
@@ -68,7 +70,7 @@ public class BlockService {
         Block block = blockRepository.findById(blockId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE));
 
-        int deletedOrderIndex = block.getOrderIndex();
+        Double deletedOrderIndex = block.getOrderIndex();
         Long postId = block.getPost().getPostId();
 
         blockRepository.delete(block);
@@ -79,5 +81,21 @@ public class BlockService {
     	Block block = blockRepository.findById(blockId)
     		    .orElseThrow(() -> new GeneralException(ErrorStatus.BLOCK_NOT_FOUND));
     	return block;
+    }
+    
+    @Transactional
+    public void reorderBlocks(Long postId, Long blockId, int newIndex) {
+    	Post post = postRepository.findById(postId)
+    			.orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
+    	
+    	List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
+    	Block movingBlock = blockRepository.findById(blockId)
+    						.orElseThrow(() -> new BlockHandler(ErrorStatus.BLOCK_NOT_FOUND));
+        
+    	double prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
+    	double next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
+    	
+    	
+        movingBlock.moveTo((prev + next) / 2);
     }
 }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -38,7 +38,7 @@ public class BlockService {
     	
     	double gap = 10;
     	
-    	double nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + gap;
+    	double nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(10) + gap;
     	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
@@ -100,22 +100,23 @@ public class BlockService {
     	Double next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	
     	if (next - prev <= 1) {
-    	    normalizeOrderIndexes(post);
+    	    normalizeOrderIndexes(post, movingBlock);
     	    blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
     	    prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
         	next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	}
-    	
-        movingBlock.moveTo((prev + next) / 2);
+
+    	movingBlock.moveTo((prev + next) / 2);
     }
     
     @Transactional
-    private void normalizeOrderIndexes(Post post) {
+    private void normalizeOrderIndexes(Post post, Block movingBlock) {
         List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
-        double index = 0;
+        double index = 10;
         double gap = 10;
 
         for (Block block : blocks) {
+        	if (block.equals(movingBlock)) continue;
             block.moveTo(index);
             index += gap;
         }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +19,8 @@ import com.doyak.reflector.repository.BlockRepository;
 import com.doyak.reflector.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -36,9 +36,9 @@ public class BlockService {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     	
-    	int gap = 10;
+    	double gap = 10;
     	
-    	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + gap;
+    	double nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + gap;
     	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
@@ -77,11 +77,7 @@ public class BlockService {
         Block block = blockRepository.findById(blockId)
                 .orElseThrow(() -> new BlockHandler(ErrorStatus.BLOCK_NOT_FOUND));
 
-        // Double deletedOrderIndex = block.getOrderIndex();
-        // Long postId = block.getPost().getPostId();
-
         blockRepository.delete(block);
-        // blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
     }
     
     private Block findBlockById(Long blockId) {
@@ -91,7 +87,7 @@ public class BlockService {
     }
     
     @Transactional
-    public void reorderBlocks(Long postId, Long blockId, int newIndex) {
+    public void reorderBlocks(Long postId, Long blockId, BlockRequest.ReorderBlock request) {
     	Post post = postRepository.findById(postId)
     			.orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
     	
@@ -99,10 +95,29 @@ public class BlockService {
     	Block movingBlock = blockRepository.findById(blockId)
     						.orElseThrow(() -> new BlockHandler(ErrorStatus.BLOCK_NOT_FOUND));
         
-    	double prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
-    	double next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
+    	Integer newIndex = request.getNewIndex();
+    	Double prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
+    	Double next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	
+    	if (next - prev <= 1) {
+    	    normalizeOrderIndexes(post);
+    	    blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
+    	    prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
+        	next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
+    	}
     	
         movingBlock.moveTo((prev + next) / 2);
+    }
+    
+    @Transactional
+    public void normalizeOrderIndexes(Post post) {
+        List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
+        double index = 0;
+        double gap = 10;
+
+        for (Block block : blocks) {
+            block.moveTo(index);
+            index += gap;
+        }
     }
 }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -11,6 +11,7 @@ import com.doyak.reflector.domain.CodeBlock;
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.TextBlock;
 import com.doyak.reflector.dto.request.BlockRequest;
+import com.doyak.reflector.dto.request.BlockRequest.BlockCommand;
 import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
@@ -31,10 +32,13 @@ public class BlockService {
 
     // 코드 블럭 생성  
     @Transactional
-    public BlockResponse createBlock(BlockRequest request, Long postId) {
+    public BlockResponse createBlock(BlockCommand request, Long postId) {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
-    	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + 1;
+    	
+    	int gap = 10;
+    	
+    	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + gap;
     	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
@@ -49,7 +53,7 @@ public class BlockService {
 
     // 블럭 수정
     @Transactional
-    public BlockResponse updateBlock(Long blockId, BlockRequest request) {
+    public BlockResponse updateBlock(Long blockId, BlockCommand request) {
         Block block = findBlockById(blockId);
 
         if (request instanceof BlockRequest.TextCommand textRequest && block instanceof TextBlock textBlock) {
@@ -63,18 +67,21 @@ public class BlockService {
         }
     }
 
-
     // 블럭 삭제 
     @Transactional
-    public void deleteBlock(Long blockId) {
+    public void deleteBlock(Long postId, Long blockId) {
+    	if (!postRepository.existsById(postId)) {
+    		throw new PostHandler(ErrorStatus.POST_NOT_FOUND);
+    	}
+    	
         Block block = blockRepository.findById(blockId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE));
+                .orElseThrow(() -> new BlockHandler(ErrorStatus.BLOCK_NOT_FOUND));
 
-        Double deletedOrderIndex = block.getOrderIndex();
-        Long postId = block.getPost().getPostId();
+        // Double deletedOrderIndex = block.getOrderIndex();
+        // Long postId = block.getPost().getPostId();
 
         blockRepository.delete(block);
-        blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
+        // blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
     }
     
     private Block findBlockById(Long blockId) {

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -20,6 +20,7 @@ import com.doyak.reflector.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -103,8 +104,7 @@ public class BlockService {
     	
     	if (next - prev <= 1) {
     	    normalizeOrderIndexes(blocks);
-    	    blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
-    	    blocks.remove(movingBlock);
+    	    blocks.sort(Comparator.comparing(Block::getOrderIndex));    	    
     	    prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
         	next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	}

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -87,7 +87,7 @@ public class BlockService {
     }
     
     @Transactional
-    public void reorderBlocks(Long postId, Long blockId, BlockRequest.ReorderBlock request) {
+    public void reorderBlock(Long postId, Long blockId, BlockRequest.ReorderBlock request) {
     	Post post = postRepository.findById(postId)
     			.orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
     	
@@ -110,7 +110,7 @@ public class BlockService {
     }
     
     @Transactional
-    public void normalizeOrderIndexes(Post post) {
+    private void normalizeOrderIndexes(Post post) {
         List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
         double index = 0;
         double gap = 10;

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -87,36 +87,39 @@ public class BlockService {
     }
     
     @Transactional
-    public void reorderBlock(Long postId, Long blockId, BlockRequest.ReorderBlock request) {
+    public List<BlockResponse> reorderBlock(Long postId, Long blockId, BlockRequest.ReorderBlock request) {
     	Post post = postRepository.findById(postId)
     			.orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
     	
     	List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
     	Block movingBlock = blockRepository.findById(blockId)
     						.orElseThrow(() -> new BlockHandler(ErrorStatus.BLOCK_NOT_FOUND));
+    	
+    	blocks.remove(movingBlock);
         
     	Integer newIndex = request.getNewIndex();
     	Double prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
     	Double next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	
     	if (next - prev <= 1) {
-    	    normalizeOrderIndexes(post, movingBlock);
+    	    normalizeOrderIndexes(blocks);
     	    blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
+    	    blocks.remove(movingBlock);
     	    prev = newIndex == 0 ? 0 : blocks.get(newIndex - 1).getOrderIndex();
         	next = newIndex == blocks.size() ? prev + 10 : blocks.get(newIndex).getOrderIndex();
     	}
 
     	movingBlock.moveTo((prev + next) / 2);
+    	blocks.add(newIndex, movingBlock);
+    	return blockConverter.toResponseList(blocks);
     }
     
     @Transactional
-    private void normalizeOrderIndexes(Post post, Block movingBlock) {
-        List<Block> blocks = blockRepository.findAllByPostOrderByOrderIndexAsc(post);
+    private void normalizeOrderIndexes(List<Block> blocks) {
         double index = 10;
         double gap = 10;
 
         for (Block block : blocks) {
-        	if (block.equals(movingBlock)) continue;
             block.moveTo(index);
             index += gap;
         }


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #25 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
포스트 내 생성된 블럭들의 순서 변경 기능 구현

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- gap 기반 정렬을 위해 블럭 생성 시 초기 orderIndex 값 10 단위로 변경
- gap 기반 블럭 순서 변경 로직 구현
- `BlockRequest.java` interface에서 class로 변경

## 🧪 테스트 체크리스트
- [x] `PATCH /api/blocks/{postId}/{blockId}` 호출로 블럭 순서 변경 -> `GET /api/posts/{postId}` 호출로 데이터베이스 업데이트 확인
- [x] gap이 1 이하로 좁아졌을때 순서 변경 시 인덱스 재정렬 확인(postgres 쿼리로 확인)

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 중간 삽입 시 gap을 활용하여 전체 재정렬 없이 위치 조정 가능하도록 로직을 구현했습니다. ([(a, 10), (b, 20), (c, 30)] 인 리스트에서 c를 2번째로 순서를 바꾸고 싶다면 [(a, 10), (c, 15), (b, 20)]로 변경)
- 반복적인 순서 변경이 일어날 시 gap이 점점 작아지게 되므로, 만약 두 블럭 사이 gap이 1 이하가 된다면 다시 10단위로 인덱스를 재설정하는 로직을 추가로 구현해두었습니다.
- 요청을 보낼 시에는 클라이언트에서의 처리를 위해 각 블럭의 실질적인 orderIndex 값(데이터베이스에 저장된 값)이 아닌 블럭 리스트의 인덱스 값으로만 요청을 보내면 되도록 구현하였습니다. e.g., [(a, 10), (b, 20), (c, 30)] 인 리스트에서 c를 2번째로 순서를 바꾸고 싶다면 orderIndex 값이 아니라 리스트에서 삽입하고 싶은 위치인 1만 보내면 됩니다. b를 마지막 순서로 바꾸고 싶다면 2를 보내면 됩니다!

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
