### PR TITLE
[#26] 해시태그 기능 추가

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -66,6 +66,13 @@ public class PostController {
 		return ApiResponse.onSuccess(null);
 	}
 	
+	@GetMapping("/hashtags")
+	@Operation(summary = "해시태그 목록 조회")
+	public ApiResponse<List<String>> getAllHashtags(@AuthenticationPrincipal User user) {
+		List<String> hashtags = postService.getAllHashtags(user);
+		return ApiResponse.onSuccess(hashtags);
+	}
+	
 	@GetMapping("/sorted")
 	@Operation(summary = "포스트 정렬")
 	public ApiResponse<Page<PostResponse.PostOverview>> getSortedPosts(@AuthenticationPrincipal User user,
@@ -76,8 +83,10 @@ public class PostController {
 														         @RequestParam(name = "page", defaultValue = "0") 
 																 @Parameter(description = "페이지 번호 입력") int page,
 														         @RequestParam(name = "size", defaultValue = "10") 
-																 @Parameter(description = "페이지 크기 입력") int size) {
-		Page<PostResponse.PostOverview> response = postService.getSortedPosts(user, sort, direction, page, size);
+																 @Parameter(description = "페이지 크기 입력") int size,
+																 @RequestParam(name = "hashtag", required = false)
+																 @Parameter(description = "해시태그 입력") String hashtag) {
+		Page<PostResponse.PostOverview> response = postService.getSortedPosts(user, sort, direction, page, size, hashtag);
 		return ApiResponse.onSuccess(response);
 		
 	}

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -1,7 +1,7 @@
 package com.doyak.reflector.converter;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
@@ -20,11 +20,11 @@ import com.doyak.reflector.payload.exception.GeneralException;
 public class BlockConverter {
 
     // Request → Entity
-    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user, Set<Hashtag> hashtags) {
+    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user) {
         if (request instanceof BlockRequest.TextCommand textReq) {
             return toTextEntity(textReq, orderIndex, post, user);
         } else if (request instanceof BlockRequest.CodeCommand codeReq) {
-            return toCodeEntity(codeReq, orderIndex, post, user, hashtags);
+            return toCodeEntity(codeReq, orderIndex, post, user);
         } else {
             throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
         }
@@ -39,7 +39,7 @@ public class BlockConverter {
                 .build();
     }
 
-    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user, Set<Hashtag> hashtags) {    	
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user) {    	
     	return CodeBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
@@ -48,7 +48,7 @@ public class BlockConverter {
                 .language(request.getLanguage())
                 .performTime(request.getPerformTime())
                 .performMem(request.getPerformMem())
-                .hashtags(hashtags)
+                .hashtags(new HashSet<>())
                 .build();
     }
 

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -2,7 +2,6 @@ package com.doyak.reflector.converter;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -71,12 +70,13 @@ public class BlockConverter {
     }
 
     private BlockResponse.Code toCodeResponse(CodeBlock block) {
+    	List<String> hashtags = block.getHashtags().stream().map(Hashtag::getHash).toList();
         return BlockResponse.Code.builder()
                 .content(block.getContent())
                 .language(block.getLanguage())
                 .performTime(block.getPerformTime())
                 .performMem(block.getPerformMem())
-                .hashtags(block.getHashtags())
+                .hashtags(hashtags)
                 .build();
     }
     

--- a/src/main/java/com/doyak/reflector/converter/BlockConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/BlockConverter.java
@@ -1,11 +1,14 @@
 package com.doyak.reflector.converter;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 import com.doyak.reflector.domain.Block;
 import com.doyak.reflector.domain.CodeBlock;
+import com.doyak.reflector.domain.Hashtag;
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.TextBlock;
 import com.doyak.reflector.domain.User;
@@ -18,11 +21,11 @@ import com.doyak.reflector.payload.exception.GeneralException;
 public class BlockConverter {
 
     // Request → Entity
-    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user) {
+    public Block toBlock(BlockRequest request, int orderIndex, Post post, User user, Set<Hashtag> hashtags) {
         if (request instanceof BlockRequest.TextCommand textReq) {
             return toTextEntity(textReq, orderIndex, post, user);
         } else if (request instanceof BlockRequest.CodeCommand codeReq) {
-            return toCodeEntity(codeReq, orderIndex, post, user);
+            return toCodeEntity(codeReq, orderIndex, post, user, hashtags);
         } else {
             throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
         }
@@ -37,8 +40,8 @@ public class BlockConverter {
                 .build();
     }
 
-    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user) {
-        return CodeBlock.builder()
+    private CodeBlock toCodeEntity(BlockRequest.CodeCommand request, int orderIndex, Post post, User user, Set<Hashtag> hashtags) {    	
+    	return CodeBlock.builder()
         		.orderIndex(orderIndex)
         		.post(post)
         		.user(user)
@@ -46,6 +49,7 @@ public class BlockConverter {
                 .language(request.getLanguage())
                 .performTime(request.getPerformTime())
                 .performMem(request.getPerformMem())
+                .hashtags(hashtags)
                 .build();
     }
 
@@ -72,9 +76,10 @@ public class BlockConverter {
                 .language(block.getLanguage())
                 .performTime(block.getPerformTime())
                 .performMem(block.getPerformMem())
+                .hashtags(block.getHashtags())
                 .build();
     }
-
+    
     // Entity List → Response List
     public List<BlockResponse> toResponseList(List<Block> blocks) {
         return blocks.stream()

--- a/src/main/java/com/doyak/reflector/domain/CodeBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/CodeBlock.java
@@ -1,11 +1,17 @@
 package com.doyak.reflector.domain;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.doyak.reflector.domain.enums.Language;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,11 +35,20 @@ public class CodeBlock extends Block {
 	private double performTime;
 	private double performMem;
 	
+	@ManyToMany
+	@JoinTable(
+			name = "codeblock_hashtag",
+			joinColumns = @JoinColumn(name = "blockId"),
+			inverseJoinColumns = @JoinColumn(name = "hashId")
+	)
+	private Set<Hashtag> hashtags = new HashSet<>();
+	
 	// 업데이트 
-	public void update(String content, Language language, double performTime, double performMem) {
+	public void update(String content, Language language, double performTime, double performMem, Set<Hashtag> hashtags) {
 	    this.content = content;
 	    this.language = language;
 	    this.performTime = performTime;
 	    this.performMem = performMem;
+	    this.hashtags = hashtags;
 	}
 }

--- a/src/main/java/com/doyak/reflector/domain/CodeBlock.java
+++ b/src/main/java/com/doyak/reflector/domain/CodeBlock.java
@@ -44,11 +44,21 @@ public class CodeBlock extends Block {
 	private Set<Hashtag> hashtags = new HashSet<>();
 	
 	// 업데이트 
-	public void update(String content, Language language, double performTime, double performMem, Set<Hashtag> hashtags) {
+	public void update(String content, Language language, double performTime, double performMem) {
 	    this.content = content;
 	    this.language = language;
 	    this.performTime = performTime;
 	    this.performMem = performMem;
-	    this.hashtags = hashtags;
+	}
+	
+	// 해시태그 추가/삭제
+	public void addHashtag(Hashtag hashtag) {
+		this.hashtags.add(hashtag);
+		hashtag.getCodeBlocks().add(this);
+	}
+	
+	public void removeHasghtag(Hashtag hashtag) {
+		this.hashtags.remove(hashtag);
+		hashtag.getCodeBlocks().remove(this);
 	}
 }

--- a/src/main/java/com/doyak/reflector/domain/Hashtag.java
+++ b/src/main/java/com/doyak/reflector/domain/Hashtag.java
@@ -9,12 +9,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Builder
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Hashtag {
 
 	@Id

--- a/src/main/java/com/doyak/reflector/domain/Hashtag.java
+++ b/src/main/java/com/doyak/reflector/domain/Hashtag.java
@@ -10,9 +10,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import lombok.Builder;
+import lombok.Getter;
 
 @Entity
 @Builder
+@Getter
 public class Hashtag {
 
 	@Id

--- a/src/main/java/com/doyak/reflector/domain/Hashtag.java
+++ b/src/main/java/com/doyak/reflector/domain/Hashtag.java
@@ -1,0 +1,27 @@
+package com.doyak.reflector.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import lombok.Builder;
+
+@Entity
+@Builder
+public class Hashtag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "hash_id")
+	private Long hashId;
+	
+	private String hash;
+	
+	@ManyToMany(mappedBy = "hashtags")
+	private Set<CodeBlock> codeBlocks = new HashSet<>();
+}

--- a/src/main/java/com/doyak/reflector/domain/Hashtag.java
+++ b/src/main/java/com/doyak/reflector/domain/Hashtag.java
@@ -30,5 +30,6 @@ public class Hashtag {
 	private String hash;
 	
 	@ManyToMany(mappedBy = "hashtags")
+	@Builder.Default
 	private Set<CodeBlock> codeBlocks = new HashSet<>();
 }

--- a/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.dto.request;
 
+import java.util.Set;
+
 import com.doyak.reflector.domain.enums.Language;
 
 import lombok.Getter;
@@ -17,6 +19,7 @@ public interface BlockRequest {
 		private Language language;
 		private double performTime;
 		private double performMem;
+		private Set<String> hashtags;
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/BlockRequest.java
@@ -1,6 +1,6 @@
 package com.doyak.reflector.dto.request;
 
-import java.util.Set;
+import java.util.List;
 
 import com.doyak.reflector.domain.enums.Language;
 
@@ -19,7 +19,7 @@ public interface BlockRequest {
 		private Language language;
 		private double performTime;
 		private double performMem;
-		private Set<String> hashtags;
+		private List<String> hashtags;
 	}
 
 }

--- a/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
@@ -1,8 +1,7 @@
 package com.doyak.reflector.dto.response;
 
-import java.util.Set;
+import java.util.List;
 
-import com.doyak.reflector.domain.Hashtag;
 import com.doyak.reflector.domain.enums.Language;
 
 import lombok.AccessLevel;
@@ -30,7 +29,7 @@ public interface BlockResponse {
         private Language language;
         private double performTime;
         private double performMem;
-        private Set<Hashtag> hashtags;
+        private List<String> hashtags;
     }
     
 }

--- a/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/BlockResponse.java
@@ -1,5 +1,8 @@
 package com.doyak.reflector.dto.response;
 
+import java.util.Set;
+
+import com.doyak.reflector.domain.Hashtag;
 import com.doyak.reflector.domain.enums.Language;
 
 import lombok.AccessLevel;
@@ -27,6 +30,7 @@ public interface BlockResponse {
         private Language language;
         private double performTime;
         private double performMem;
+        private Set<Hashtag> hashtags;
     }
     
 }

--- a/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
@@ -1,15 +1,27 @@
 package com.doyak.reflector.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.doyak.reflector.domain.Hashtag;
+import com.doyak.reflector.domain.User;
 
 @Repository
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
 	Optional<Hashtag> findByHash(String tag);
 
+	@Query("SELECT DISTINCT h.hash FROM Hashtag h " +
+			"JOIN h.codeBlocks cb " +
+			"JOIN cb.post p " +
+			"WHERE p.user = :user")
+	List<String> findAllHashStringsByUserId(@Param("user") User user);
+
+	Set<Hashtag> findByHashIn(Set<String> tagNames);
 }

--- a/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
@@ -23,5 +23,5 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 			"WHERE p.user = :user")
 	List<String> findAllHashStringsByUserId(@Param("user") User user);
 
-	Set<Hashtag> findByHashIn(Set<String> tagNames);
+	Set<Hashtag> findByHashIn(List<String> tagNames);
 }

--- a/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/HashtagRepository.java
@@ -1,0 +1,15 @@
+package com.doyak.reflector.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.doyak.reflector.domain.Hashtag;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+	Optional<Hashtag> findByHash(String tag);
+
+}

--- a/src/main/java/com/doyak/reflector/repository/PostRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/PostRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +20,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.blocks WHERE p.postId = :postId")
     Optional<Post> findByIdWithBlocks(@Param("postId") Long postId);
+    
+    @Query(value = "SELECT DISTINCT p FROM Post p " +
+				   "JOIN p.blocks b " +
+				   "JOIN CodeBlock cb ON cb.blockId = b.blockId " +
+				   "JOIN cb.hashtags h " +
+				   "WHERE p.user = :user AND h.hash = :hash",
+		   countQuery = "SELECT COUNT(DISTINCT p) FROM Post p " +
+				   		"JOIN p.blocks b " +
+				   		"JOIN CodeBlock cb ON cb.blockId = b.blockId " +
+				   		"JOIN cb.hashtags h " +
+				   		"WHERE p.user = :user AND h.hash = :hash")
+	Page<Post> findByUserAndHashtag(@Param("user") User user, @Param("hash") String hash, Pageable pageable);
+     
 }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -104,7 +104,7 @@ public class BlockService {
             .map(Hashtag::getHash)
             .collect(Collectors.toSet());
         // 새로 만들 해시태그 
-        List<Hashtag> newTags = tagNames.stream()
+        List<Hashtag> newTags = tagNames.stream().distinct()
         	    .filter(name -> !existingNames.contains(name))
         	    .map(name -> Hashtag.builder().hash(name).build())
         	    .collect(Collectors.toList());

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -84,6 +84,13 @@ public class BlockService {
     public void deleteBlock(Long blockId) {
         Block block = blockRepository.findById(blockId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE));
+        
+        if (block instanceof CodeBlock codeBlock) {
+            for (Hashtag hashtag : codeBlock.getHashtags()) {
+                hashtag.getCodeBlocks().remove(codeBlock);
+            }
+            codeBlock.getHashtags().clear();
+        }
 
         int deletedOrderIndex = block.getOrderIndex();
         Long postId = block.getPost().getPostId();

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -1,6 +1,7 @@
 package com.doyak.reflector.service;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -98,12 +99,24 @@ public class BlockService {
         blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
     }
     
-    private Set<Hashtag> getHashtags (Set<String> tags) {
-    	Set<Hashtag> hashtags = tags.stream()
-        	    .map(tag -> hashtagRepository.findByHash(tag)
-        	            .orElseGet(() -> hashtagRepository.save(Hashtag.builder().hash(tag).build())))
-        	    .collect(Collectors.toSet());
-    	return hashtags;
+    private Set<Hashtag> getHashtags(Set<String> tagNames) {
+        // 이미 존재하는 해시태그 
+        Set<Hashtag> existing = hashtagRepository.findByHashIn(tagNames);
+        Set<String> existingNames = existing.stream()
+            .map(Hashtag::getHash)
+            .collect(Collectors.toSet());
+        // 새로 만들 해시태그 
+        Set<Hashtag> newTags = tagNames.stream()
+            .filter(name -> !existingNames.contains(name))
+            .map(name -> Hashtag.builder().hash(name).build())
+            .map(hashtagRepository::save)
+            .collect(Collectors.toSet());
+
+        // 기존 + 새 태그 합치기
+        Set<Hashtag> allTags = new HashSet<>(existing);
+        allTags.addAll(newTags);
+
+        return allTags;
     }
     
     private Block findBlockById(Long blockId) {

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -1,6 +1,9 @@
 package com.doyak.reflector.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.doyak.reflector.converter.BlockConverter;
 import com.doyak.reflector.domain.Block;
 import com.doyak.reflector.domain.CodeBlock;
+import com.doyak.reflector.domain.Hashtag;
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.TextBlock;
 import com.doyak.reflector.dto.request.BlockRequest;
@@ -15,6 +19,7 @@ import com.doyak.reflector.dto.response.BlockResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
 import com.doyak.reflector.repository.BlockRepository;
+import com.doyak.reflector.repository.HashtagRepository;
 import com.doyak.reflector.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -26,14 +31,20 @@ public class BlockService {
 	private final PostRepository postRepository;
     private final BlockRepository blockRepository;
     private final BlockConverter blockConverter; 
+    
+    private final HashtagRepository hashtagRepository;
 
-    // 코드 블럭 생성  
+    // 블럭 생성  
     @Transactional
     public BlockResponse createBlock(BlockRequest request, Long postId) {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + 1;
-    	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
+        Set<Hashtag> hashtags = Collections.emptySet();
+    	if (request instanceof BlockRequest.CodeCommand codeRequest) {
+            hashtags = getHashtags(codeRequest.getHashtags()); 
+    	}
+    	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser(), hashtags);
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
     }
@@ -54,7 +65,13 @@ public class BlockService {
             textBlock.update(textRequest.getContent());
             return blockConverter.toResponse(textBlock);
         } else if (request instanceof BlockRequest.CodeCommand codeRequest && block instanceof CodeBlock codeBlock) {
-        	codeBlock.update(codeRequest.getContent(), codeRequest.getLanguage(), codeRequest.getPerformTime(), codeRequest.getPerformMem());
+        	Set<Hashtag> hashtags = getHashtags(codeRequest.getHashtags());
+        	codeBlock.getHashtags().clear();
+        	codeBlock.getHashtags().addAll(hashtags);
+        	
+        	codeBlock.update(codeRequest.getContent(),codeRequest.getLanguage(), 
+        			codeRequest.getPerformTime(), codeRequest.getPerformMem(), codeBlock.getHashtags()
+        	);
             return blockConverter.toResponse(codeBlock);
         } else {
         	throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
@@ -73,6 +90,14 @@ public class BlockService {
 
         blockRepository.delete(block);
         blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
+    }
+    
+    private Set<Hashtag> getHashtags (Set<String> tags) {
+    	Set<Hashtag> hashtags = tags.stream()
+        	    .map(tag -> hashtagRepository.findByHash(tag)
+        	            .orElseGet(() -> hashtagRepository.save(Hashtag.builder().hash(tag).build())))
+        	    .collect(Collectors.toSet());
+    	return hashtags;
     }
     
     private Block findBlockById(Long blockId) {

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -102,8 +102,7 @@ public class BlockService {
             codeBlock.getHashtags().clear();
         }
 
-        int deletedOrderIndex = block.getOrderIndex();
-        Long postId = block.getPost().getPostId();
+        Double deletedOrderIndex = block.getOrderIndex();
 
         blockRepository.delete(block);
     }

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -2,6 +2,7 @@ package com.doyak.reflector.service;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -99,7 +100,7 @@ public class BlockService {
         blockRepository.decrementOrderIndexAfter(postId, deletedOrderIndex);
     }
     
-    private Set<Hashtag> getHashtags(Set<String> tagNames) {
+    private Set<Hashtag> getHashtags(List<String> tagNames) {
         // 이미 존재하는 해시태그 
         Set<Hashtag> existing = hashtagRepository.findByHashIn(tagNames);
         Set<String> existingNames = existing.stream()

--- a/src/main/java/com/doyak/reflector/service/BlockService.java
+++ b/src/main/java/com/doyak/reflector/service/BlockService.java
@@ -1,6 +1,5 @@
 package com.doyak.reflector.service;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,11 +40,12 @@ public class BlockService {
     	Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
     	int nextOrderIndex = blockRepository.findMaxOrderIndexByPost(post).orElse(0) + 1;
-        Set<Hashtag> hashtags = Collections.emptySet();
-    	if (request instanceof BlockRequest.CodeCommand codeRequest) {
-            hashtags = getHashtags(codeRequest.getHashtags()); 
-    	}
-    	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser(), hashtags);
+    	Block block = blockConverter.toBlock(request, nextOrderIndex, post, post.getUser());
+    	if (request instanceof BlockRequest.CodeCommand codeRequest && block instanceof CodeBlock codeBlock) {
+            Set<Hashtag> hashtags = getHashtags(codeRequest.getHashtags());
+            hashtags.forEach(codeBlock::addHashtag);
+        }
+    	post.getBlocks().add(block);
     	Block saved = blockRepository.save(block);
     	return blockConverter.toResponse(saved);
     }
@@ -66,13 +66,12 @@ public class BlockService {
             textBlock.update(textRequest.getContent());
             return blockConverter.toResponse(textBlock);
         } else if (request instanceof BlockRequest.CodeCommand codeRequest && block instanceof CodeBlock codeBlock) {
-        	Set<Hashtag> hashtags = getHashtags(codeRequest.getHashtags());
-        	codeBlock.getHashtags().clear();
-        	codeBlock.getHashtags().addAll(hashtags);
+        	Set<Hashtag> newHashtags = getHashtags(codeRequest.getHashtags());
+            codeBlock.getHashtags().removeIf(tag -> !newHashtags.contains(tag));
+            newHashtags.forEach(tag -> codeBlock.getHashtags().add(tag));
         	
         	codeBlock.update(codeRequest.getContent(),codeRequest.getLanguage(), 
-        			codeRequest.getPerformTime(), codeRequest.getPerformMem(), codeBlock.getHashtags()
-        	);
+        			codeRequest.getPerformTime(), codeRequest.getPerformMem());
             return blockConverter.toResponse(codeBlock);
         } else {
         	throw new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE);
@@ -87,9 +86,7 @@ public class BlockService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_BLOCK_TYPE));
         
         if (block instanceof CodeBlock codeBlock) {
-            for (Hashtag hashtag : codeBlock.getHashtags()) {
-                hashtag.getCodeBlocks().remove(codeBlock);
-            }
+            codeBlock.getHashtags().forEach(h -> h.getCodeBlocks().remove(codeBlock));
             codeBlock.getHashtags().clear();
         }
 
@@ -107,11 +104,11 @@ public class BlockService {
             .map(Hashtag::getHash)
             .collect(Collectors.toSet());
         // 새로 만들 해시태그 
-        Set<Hashtag> newTags = tagNames.stream()
-            .filter(name -> !existingNames.contains(name))
-            .map(name -> Hashtag.builder().hash(name).build())
-            .map(hashtagRepository::save)
-            .collect(Collectors.toSet());
+        List<Hashtag> newTags = tagNames.stream()
+        	    .filter(name -> !existingNames.contains(name))
+        	    .map(name -> Hashtag.builder().hash(name).build())
+        	    .collect(Collectors.toList());
+    	hashtagRepository.saveAll(newTags);
 
         // 기존 + 새 태그 합치기
         Set<Hashtag> allTags = new HashSet<>(existing);

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -1,5 +1,8 @@
 package com.doyak.reflector.service;
 
+import java.awt.print.Pageable;
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -15,6 +18,7 @@ import com.doyak.reflector.dto.response.PostResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
 import com.doyak.reflector.payload.exception.GeneralException;
 import com.doyak.reflector.payload.exception.handler.PostHandler;
+import com.doyak.reflector.repository.HashtagRepository;
 import com.doyak.reflector.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostService {
     
+	private final HashtagRepository hashtagRepository;
     private final PostRepository postRepository;
     private final PostConverter postConverter;
 
@@ -61,9 +66,14 @@ public class PostService {
     }
     
     @Transactional(readOnly = true)
-    public Page<PostResponse.PostOverview> getSortedPosts(User user, SortType sort, Sort.Direction direction, int page, int size) {
+    public Page<PostResponse.PostOverview> getSortedPosts(User user, SortType sort, Sort.Direction direction, int page, int size, String hash) {
     	PageRequest pageRequest = PageRequest.of(page, size, Sort.by(direction, sort.getField()));
-    	Page<Post> posts = postRepository.findAllByUser(user, pageRequest);
+    	Page<Post> posts;
+    	if (hash == null) {
+    		posts = postRepository.findAllByUser(user, pageRequest);
+    	} else {
+    		posts = postRepository.findByUserAndHashtag(user, hash, pageRequest);
+    	}
     	
     	if (posts.isEmpty()) {
     		throw new PostHandler(ErrorStatus.POST_NOT_FOUND);
@@ -74,6 +84,10 @@ public class PostService {
         }
     	
     	return postConverter.toResponsePage(posts);
+    }
+    
+    public List<String> getAllHashtags(User user) {
+    	return hashtagRepository.findAllHashStringsByUserId(user);
     }
    
     private Post findPostWithBlocks(User user, Long postId) {

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -58,7 +58,7 @@ public class PostService {
     public void deletePost(User user, Long postId) {
     	Post post = findPostById(user, postId);
     	for (Block block : post.getBlocks()) {
-    		blockService.deleteBlock(block.getBlockId());
+    		blockService.deleteBlock(post.getPostId(), block.getBlockId());
     	}
         postRepository.deleteById(postId);
     }

--- a/src/main/java/com/doyak/reflector/service/PostService.java
+++ b/src/main/java/com/doyak/reflector/service/PostService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.doyak.reflector.converter.PostConverter;
+import com.doyak.reflector.domain.Block;
+import com.doyak.reflector.domain.CodeBlock;
 import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.domain.enums.SortType;
@@ -27,9 +29,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostService {
     
-	private final HashtagRepository hashtagRepository;
     private final PostRepository postRepository;
     private final PostConverter postConverter;
+	private final HashtagRepository hashtagRepository;
+	private final BlockService blockService;
 
     @Transactional
     public PostResponse.PostInfo createPost(User user, PostRequest.PostCommand command) {
@@ -53,6 +56,10 @@ public class PostService {
 
     @Transactional
     public void deletePost(User user, Long postId) {
+    	Post post = findPostById(user, postId);
+    	for (Block block : post.getBlocks()) {
+    		blockService.deleteBlock(block.getBlockId());
+    	}
         postRepository.deleteById(postId);
     }
 


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #26 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
해시태그 기능 추가

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 코드블럭 생성 시 해시태그 추가
- 포스트 정렬 함수에 해시태그 조건 추가

## 🧪 테스트 체크리스트
- [x] 코드블럭에 해시테그 추가, 수정, 삭제 확인
- [x] 포스트 정렬(전체/특정 해시태그) 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
포스트 정렬 시 hash 필드에 특정 해시태크를 넣으면 해당 해시태그가 포함된 포스트를 리턴, null(아무것도 담지 않으면)을 보내면 전체 포스트를 리턴합니다.
코드블럭에 해시태그 넣을 때, 같은 해시태그를 여러개 넣으면 하나로만 담깁니다.

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
