### PR TITLE
[#27] 학습 트래커 불러오기 기능 구현

### DIFF
--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -1,7 +1,5 @@
 package com.doyak.reflector.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/doyak/reflector/controller/PostController.java
+++ b/src/main/java/com/doyak/reflector/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,11 +1,16 @@
 package com.doyak.reflector.controller;
 
+import java.time.LocalDate;
+import java.util.Map;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.doyak.reflector.domain.User;
@@ -76,6 +81,13 @@ public class UserController {
 	public ApiResponse<Void> verifyCode(@Valid @RequestBody UserRequest.EmailCodeDTO request) {
 		emailService.verifyEmailCode(request);
 		return ApiResponse.onSuccess(null);
+	}
+	
+	@GetMapping("/study-tracker/{year}")
+	@Operation(summary = "학습 트래커 로그 불러오기", description = "원하는 연도를 입력해주세요.")
+	public ApiResponse<Map<LocalDate, Long>> getStudyLogs(@AuthenticationPrincipal User user, @RequestParam(name = "year", defaultValue = "2025") Integer year) {
+		Map<LocalDate, Long> response = userService.getCalendarDate(user, year);
+		return ApiResponse.onSuccess(response);
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.doyak.reflector.controller;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -85,8 +86,8 @@ public class UserController {
 	
 	@GetMapping("/study-tracker/{year}")
 	@Operation(summary = "학습 트래커 로그 불러오기", description = "원하는 연도를 입력해주세요.")
-	public ApiResponse<Map<LocalDate, Long>> getStudyLogs(@AuthenticationPrincipal User user, @RequestParam(name = "year", defaultValue = "2025") Integer year) {
-		Map<LocalDate, Long> response = userService.getCalendarDate(user, year);
+	public ApiResponse<List<UserResponse.UserTrackerDTO>> getTrackers(@AuthenticationPrincipal User user, @RequestParam(name = "year", defaultValue = "2025") Integer year) {
+		List<UserResponse.UserTrackerDTO> response = userService.getCalendarDate(user, year);
 		return ApiResponse.onSuccess(response);
 	}
 	

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -1,17 +1,15 @@
 package com.doyak.reflector.controller;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.doyak.reflector.domain.User;
@@ -86,7 +84,8 @@ public class UserController {
 	
 	@GetMapping("/study-tracker/{year}")
 	@Operation(summary = "학습 트래커 로그 불러오기", description = "원하는 연도를 입력해주세요.")
-	public ApiResponse<List<UserResponse.UserTrackerDTO>> getTrackers(@AuthenticationPrincipal User user, @RequestParam(name = "year", defaultValue = "2025") Integer year) {
+	public ApiResponse<List<UserResponse.UserTrackerDTO>> getTrackers(@AuthenticationPrincipal User user, 
+																	  @PathVariable("year") Integer year) {
 		List<UserResponse.UserTrackerDTO> response = userService.getCalendarDate(user, year);
 		return ApiResponse.onSuccess(response);
 	}

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -1,5 +1,10 @@
 package com.doyak.reflector.converter;
 
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.dto.request.UserRequest;
@@ -24,6 +29,16 @@ public class UserConverter {
 		return UserResponse.UserUpdateDTO.builder()
 				.email(user.getEmail())
 				.build();
+	}
+	
+	public static List<UserResponse.UserTrackerDTO> toTrackerResponse(Map<LocalDate, Long> logs) {
+		return logs.entrySet().stream()
+		        .map(entry -> UserResponse.UserTrackerDTO.builder()
+		                .date(entry.getKey())
+		                .count(entry.getValue())
+		                .build())
+		        .sorted(Comparator.comparing(UserResponse.UserTrackerDTO::getDate))
+		        .toList();
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -4,9 +4,11 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.response.UserResponse;
+import com.doyak.reflector.dto.response.UserResponse.UserTrackerDTO;
 import com.doyak.reflector.dto.request.UserRequest;
 
 public class UserConverter {
@@ -31,14 +33,13 @@ public class UserConverter {
 				.build();
 	}
 	
-	public static List<UserResponse.UserTrackerDTO> toTrackerResponse(Map<LocalDate, Long> logs) {
-		return logs.entrySet().stream()
-		        .map(entry -> UserResponse.UserTrackerDTO.builder()
-		                .date(entry.getKey())
-		                .count(entry.getValue())
-		                .build())
-		        .sorted(Comparator.comparing(UserResponse.UserTrackerDTO::getDate))
-		        .toList();
+	public static List<UserResponse.UserTrackerDTO> toTrackerResponse(List<Object[]> queryResult) {
+		return queryResult.stream()
+    			.map(o -> UserTrackerDTO.builder()
+    	                .date(((java.sql.Date) o[0]).toLocalDate())
+    	                .count(((Long) o[1]))                       
+    	                .build()                       
+    	        ).collect(Collectors.toList());
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -48,19 +48,18 @@ public class UserRequest {
 		
 		@NotBlank(message = "비밀번호를 입력해주세요. 변경하지 않을 것이라면 기존의 비밀번호를 입력해주세요.")
 		String password;
-  }
+	}
   
-  @Builder
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  @AllArgsConstructor
-  @Getter
+	@Builder
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	@Getter
 	public static class UserEmailDTO {
-		
 		@NotBlank(message = "이메일은 필수 입력 값입니다.")
 		String email;
 	}
 	
-	  @Builder
+	@Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -24,5 +24,5 @@ public class UserResponse {
     public static class UserUpdateDTO {
 		String email;
 	}
-
+	
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.dto.response;
 
+import java.time.LocalDate;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,8 +15,8 @@ public class UserResponse {
     @AllArgsConstructor
     @Getter
     public static class UserLoginResponseDTO {
-		String email;
-		String token;
+		private String email;
+		private String token;
 	}
 	
 	@Builder
@@ -22,7 +24,16 @@ public class UserResponse {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateDTO {
-		String email;
+		private String email;
+	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class UserTrackerDTO {
+		private LocalDate date;
+		private Long count;
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/repository/PostRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/PostRepository.java
@@ -1,5 +1,7 @@
 package com.doyak.reflector.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -19,4 +21,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.blocks WHERE p.postId = :postId")
     Optional<Post> findByIdWithBlocks(@Param("postId") Long postId);
+    
+    List<Post> findAllByUserAndCreatedAtBetween(User user, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/doyak/reflector/repository/PostRepository.java
+++ b/src/main/java/com/doyak/reflector/repository/PostRepository.java
@@ -22,5 +22,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.blocks WHERE p.postId = :postId")
     Optional<Post> findByIdWithBlocks(@Param("postId") Long postId);
     
-    List<Post> findAllByUserAndCreatedAtBetween(User user, LocalDateTime from, LocalDateTime to);
+    @Query("SELECT FUNCTION('DATE', p.createdAt) as date, COUNT(p) as count " +
+    		"FROM Post p WHERE p.user = :user AND p.createdAt BETWEEN :from AND :to " +
+    		"GROUP BY FUNCTION('DATE', p.createdAt) " +
+    		"ORDER BY date")
+    List<Object[]> countPostGroupedByDate(
+    		@Param("user") User user, 
+    		@Param("from") LocalDateTime from, 
+    		@Param("to") LocalDateTime to);
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -4,7 +4,6 @@ package com.doyak.reflector.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -94,7 +93,7 @@ public class UserService {
     }
     
     @Transactional(readOnly = true)
-    public Map<LocalDate, Long> getCalendarDate(User user, Integer year) {
+    public List<UserResponse.UserTrackerDTO> getCalendarDate(User user, Integer year) {
     	User findUser = userRepository.findByEmail(user.getEmail())
 				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     	
@@ -106,19 +105,21 @@ public class UserService {
     	LocalDateTime end = endDate.atTime(LocalTime.MAX);  
     	
     	List<Post> posts = postRepository.findAllByUserAndCreatedAtBetween(findUser, start, end);
-    	Map<LocalDate, Long> calendarMap = posts.stream()
+    	Map<LocalDate, Long> logs = posts.stream()
     			.collect(Collectors.groupingBy(
     					post -> post.getCreatedAt().toLocalDate(),
     	                Collectors.counting()
     					));
     	
-//    	Map<LocalDate, Long> result = new LinkedHashMap<>();
-//        LocalDate cursor = startDate;
-//        while (!cursor.isAfter(endDate)) {
-//            result.put(cursor, calendarMap.getOrDefault(cursor, (long) 0));
-//            cursor = cursor.plusDays(1);
-//        }
+    	/* 전체 날짜 불러오기 (학습 기록이 없는 날은 0)
+    	Map<LocalDate, Long> result = new LinkedHashMap<>();
+        LocalDate cursor = startDate;
+        while (!cursor.isAfter(endDate)) {
+            result.put(cursor, calendarMap.getOrDefault(cursor, (long) 0));
+            cursor = cursor.plusDays(1);
+        }
+        */
 
-        return calendarMap;
+        return UserConverter.toTrackerResponse(logs);
     }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -21,6 +21,7 @@ import com.doyak.reflector.repository.UserRepository;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
+import com.doyak.reflector.payload.exception.handler.PostHandler;
 import com.doyak.reflector.payload.exception.handler.UserHandler;
 
 import lombok.RequiredArgsConstructor;
@@ -105,6 +106,11 @@ public class UserService {
     	LocalDateTime end = endDate.atTime(LocalTime.MAX);  
     	
     	List<Post> posts = postRepository.findAllByUserAndCreatedAtBetween(findUser, start, end);
+    	
+    	if (posts.isEmpty()) {
+    	    throw new PostHandler(ErrorStatus.POST_NOT_FOUND);
+    	}
+    	
     	Map<LocalDate, Long> logs = posts.stream()
     			.collect(Collectors.groupingBy(
     					post -> post.getCreatedAt().toLocalDate(),

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -5,8 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.doyak.reflector.auth.JwtUtil;
 import com.doyak.reflector.converter.UserConverter;
-import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.repository.PostRepository;
 import com.doyak.reflector.repository.UserRepository;
@@ -105,27 +102,25 @@ public class UserService {
     	LocalDateTime start = startDate.atStartOfDay();
     	LocalDateTime end = endDate.atTime(LocalTime.MAX);  
     	
-    	List<Post> posts = postRepository.findAllByUserAndCreatedAtBetween(findUser, start, end);
+    	List<Object[]> queryResult = postRepository.countPostGroupedByDate(findUser, start, end);
     	
-    	if (posts.isEmpty()) {
+    	if (queryResult.isEmpty()) {
     	    throw new PostHandler(ErrorStatus.POST_NOT_FOUND);
     	}
     	
-    	Map<LocalDate, Long> logs = posts.stream()
-    			.collect(Collectors.groupingBy(
-    					post -> post.getCreatedAt().toLocalDate(),
-    	                Collectors.counting()
-    					));
     	
     	/* 전체 날짜 불러오기 (학습 기록이 없는 날은 0)
-    	Map<LocalDate, Long> result = new LinkedHashMap<>();
-        LocalDate cursor = startDate;
-        while (!cursor.isAfter(endDate)) {
-            result.put(cursor, calendarMap.getOrDefault(cursor, (long) 0));
-            cursor = cursor.plusDays(1);
-        }
+        Map<LocalDate, Long> calendarMap = logs.stream()
+   			.collect(Collectors.toMap(UserTrackerDTO::getDate, UserTrackerDTO::getCount));
+
+		Map<LocalDate, Long> result = new LinkedHashMap<>();
+		LocalDate cursor = startDate;
+		while (!cursor.isAfter(endDate)) {
+		    result.put(cursor, calendarMap.getOrDefault(cursor, 0L));
+		    cursor = cursor.plusDays(1);
+		}
         */
 
-        return UserConverter.toTrackerResponse(logs);
+        return UserConverter.toTrackerResponse(queryResult);
     }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -1,13 +1,23 @@
 package com.doyak.reflector.service;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.doyak.reflector.auth.JwtUtil;
 import com.doyak.reflector.converter.UserConverter;
+import com.doyak.reflector.domain.Post;
 import com.doyak.reflector.domain.User;
+import com.doyak.reflector.repository.PostRepository;
 import com.doyak.reflector.repository.UserRepository;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
@@ -23,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 	
 	private final UserRepository userRepository;
+	private final PostRepository postRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     
@@ -80,5 +91,34 @@ public class UserService {
     	
     	userRepository.delete(findUser);
     	log.info("Successfully delete user");
+    }
+    
+    @Transactional(readOnly = true)
+    public Map<LocalDate, Long> getCalendarDate(User user, Integer year) {
+    	User findUser = userRepository.findByEmail(user.getEmail())
+				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    	
+    	
+    	LocalDate startDate = LocalDate.of(year,  1,  1);
+    	LocalDate endDate = LocalDate.of(year, 12, 31);
+
+    	LocalDateTime start = startDate.atStartOfDay();
+    	LocalDateTime end = endDate.atTime(LocalTime.MAX);  
+    	
+    	List<Post> posts = postRepository.findAllByUserAndCreatedAtBetween(findUser, start, end);
+    	Map<LocalDate, Long> calendarMap = posts.stream()
+    			.collect(Collectors.groupingBy(
+    					post -> post.getCreatedAt().toLocalDate(),
+    	                Collectors.counting()
+    					));
+    	
+//    	Map<LocalDate, Long> result = new LinkedHashMap<>();
+//        LocalDate cursor = startDate;
+//        while (!cursor.isAfter(endDate)) {
+//            result.put(cursor, calendarMap.getOrDefault(cursor, (long) 0));
+//            cursor = cursor.plusDays(1);
+//        }
+
+        return calendarMap;
     }
 }


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #27 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
날짜별 사용자가 게시글을 생성한 횟수를 반환하여 학습 이력을 추적할 수 있는 학습 트래커 기능 구현

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 연도별 post 생성 날짜에 따른 게시글 생성 횟수 합산 내역 조회 기능 구현
- 학습 기록이 없는 날은 횟수를 0으로 초기화하여 파라미터로 받은 연도의 전체 학습 로그 조회 기능 구현

## 🧪 테스트 체크리스트
- [x] `GET /api/users/study-tracker/{year}` 조회 응답 확인
- [x] 접근 권한/작성한 post가 하나도 없는 경우 등의 예외 처리 확인

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 전체 날짜 학습 로그를 다루기 위해, 학습하지 않은 날은 count를 0으로 해서 연도 전체를 응답하도록 하는 로직도 만들어두었습니다! 그런데 전체 날짜를 모두 응답하는 것은 불필요할 것 같아 지금은 학습 로그가 있는 날만 보내도록 해놨고, 프론트에서 연도 전체 정보가 필요하면 주석을 푼 후 converter의 파라미터만 수정하면 쓸 수 있도록 해두었습니다.
- 우선은 path parameter로 받은 연도의 날짜별 학습 로그만 출력하도록 구현하였습니다. 추후 새로운 학습 데이터 분석이 필요하다면 해당 메소드에 query parameter를 추가하는 방식으로도 확장 가능할 것 같습니다!

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
