### PR TITLE
[#35] JWT 관련 설정 추가

### DIFF
--- a/src/main/java/com/doyak/reflector/auth/JwtUtil.java
+++ b/src/main/java/com/doyak/reflector/auth/JwtUtil.java
@@ -42,11 +42,12 @@ public class JwtUtil {
     }
     
     // 토큰 생성 - 추후 만료 시간 추가 예정 
-    public String createAccessToken(User user) {
+    public String createToken(String category, User user, int expirationMillis) {
         return Jwts.builder()
-                .claims(createClaims(user))
+                .claims(createClaims(user, category))
                 .subject(String.valueOf(user.getId()))
                 .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expirationMillis))
                 .signWith(secretKey)
                .compact();
     }
@@ -76,24 +77,19 @@ public class JwtUtil {
         }
     }
     
-    private static Map<String, Object> createClaims(User user) {
+    private static Map<String, Object> createClaims(User user, String category) {
     	Map<String, Object> claims = new HashMap<>();
     	
-    	log.info("userId: " + user.getId());
-        log.info("userEmail: " + user.getEmail());
-        
+        claims.put("category", category);
         claims.put("userId", user.getId());
         claims.put("userEmail", user.getEmail());
         return claims;
     }
     
-    
-    
     public Authentication getAuthentication(String token) throws UsernameNotFoundException {
         UserDetails userDetails = userDetailService.loadUserByUsername(this.getUserEmail(token));
         return new UsernamePasswordAuthenticationToken(userDetails, null, null);
     }
-    
     
     public String getUserEmail(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userEmail", String.class);

--- a/src/main/java/com/doyak/reflector/auth/JwtUtil.java
+++ b/src/main/java/com/doyak/reflector/auth/JwtUtil.java
@@ -91,6 +91,10 @@ public class JwtUtil {
         return new UsernamePasswordAuthenticationToken(userDetails, null, null);
     }
     
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+    
     public String getUserEmail(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userEmail", String.class);
     }

--- a/src/main/java/com/doyak/reflector/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/doyak/reflector/auth/filter/JwtAuthenticationFilter.java
@@ -30,13 +30,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = jwtUtil.resolveToken(request);
         
         if (accessToken == null) {
-        	sendError(response, "Access token missing");
+        	filterChain.doFilter(request, response);
         	return;
         }
         
         String category = jwtUtil.getCategory(accessToken);
         if (!"access".equals(category) || !jwtUtil.validateToken(accessToken)) {
-            sendError(response, "invalid or expired access token");
+        	filterChain.doFilter(request, response);
             return;
         }
         

--- a/src/main/java/com/doyak/reflector/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/doyak/reflector/auth/filter/JwtAuthenticationFilter.java
@@ -28,13 +28,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = jwtUtil.resolveToken(request);
-
-        if (accessToken != null && jwtUtil.validateToken(accessToken)) {
-            Authentication auth = jwtUtil.getAuthentication(accessToken);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+        
+        if (accessToken == null) {
+        	sendError(response, "Access token missing");
+        	return;
         }
+        
+        String category = jwtUtil.getCategory(accessToken);
+        if (!"access".equals(category) || !jwtUtil.validateToken(accessToken)) {
+            sendError(response, "invalid or expired access token");
+            return;
+        }
+        
+        Authentication auth = jwtUtil.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(auth);
 
         filterChain.doFilter(request, response);
+    }
+    
+    private void sendError(HttpServletResponse response, String message) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
     }
 
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -100,12 +100,10 @@ public class UserController {
 	
 	@PostMapping("/reissue")
 	@Operation(summary = "토큰 재발급", description = "로그인할 유저의 이메일과 비밀번호를 입력해주세요.")
-	public ApiResponse<UserResponse.UserLoginResponseDTO> reissue(HttpServletRequest request, 
-																HttpServletResponse response) {
+	public ApiResponse<UserResponse.UserLoginResponseDTO> reissue(HttpServletRequest request) {
 		String refreshToken = cookieUtil.getRefreshToken(request);
-		UserResponse.UserLoginWrapperDTO loginWrapper = userService.reissue(refreshToken);
-		cookieUtil.addRefreshTokenCookie(response, loginWrapper.getRefreshToken());
-		return ApiResponse.onSuccess(loginWrapper.getLoginResponse());
+		UserResponse.UserLoginResponseDTO response = userService.reissue(refreshToken);
+		return ApiResponse.onSuccess(response);
 	}
 	
 	@DeleteMapping("/logout")

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -15,11 +15,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
+import com.doyak.reflector.dto.response.UserResponse.UserSignupResponseDTO;
 import com.doyak.reflector.payload.ApiResponse;
 import com.doyak.reflector.service.EmailService;
 import com.doyak.reflector.service.UserService;
+import com.doyak.reflector.util.CookieUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -32,18 +36,22 @@ public class UserController {
 	
 	private final EmailService emailService;
 	
+	private final CookieUtil cookieUtil;
+	
 	@PostMapping("/sign-up")
 	@Operation(summary = "회원가입", description = "회원가입에 사용할 이메일과 비밀번호를 입력해주세요.")
-	public ApiResponse<UserResponse.UserLoginResponseDTO> signup(@Valid @RequestBody UserRequest.UserSignUpDTO request) {
-		UserResponse.UserLoginResponseDTO response = userService.signup(request);
+	public ApiResponse<UserResponse.UserSignupResponseDTO> signup(@Valid @RequestBody UserRequest.UserSignUpDTO request) {
+		UserSignupResponseDTO response = userService.signup(request);
 		return ApiResponse.onSuccess(response);
 	}
 	
 	@PostMapping("/login")
 	@Operation(summary = "로그인", description = "로그인할 유저의 이메일과 비밀번호를 입력해주세요.")
-	public ApiResponse<UserResponse.UserLoginResponseDTO> login(@Valid @RequestBody UserRequest.UserLoginDTO request) {
-		UserResponse.UserLoginResponseDTO response = userService.login(request);
-		return ApiResponse.onSuccess(response);
+	public ApiResponse<UserResponse.UserLoginResponseDTO> login(@Valid @RequestBody UserRequest.UserLoginDTO request, 
+																HttpServletResponse response) {
+		UserResponse.UserLoginWrapperDTO loginWrapper = userService.login(request);
+		cookieUtil.addRefreshTokenCookie(response, loginWrapper.getRefreshToken());
+		return ApiResponse.onSuccess(loginWrapper.getLoginResponse());
 	}
 	
 	@PutMapping
@@ -88,6 +96,16 @@ public class UserController {
 																	  @PathVariable("year") Integer year) {
 		List<UserResponse.UserTrackerDTO> response = userService.getCalendarDate(user, year);
 		return ApiResponse.onSuccess(response);
+	}
+	
+	@PostMapping("/reissue")
+	@Operation(summary = "토큰 재발급", description = "로그인할 유저의 이메일과 비밀번호를 입력해주세요.")
+	public ApiResponse<UserResponse.UserLoginResponseDTO> reissue(HttpServletRequest request, 
+																HttpServletResponse response) {
+		String refreshToken = cookieUtil.getRefreshToken(request);
+		UserResponse.UserLoginWrapperDTO loginWrapper = userService.reissue(refreshToken);
+		cookieUtil.addRefreshTokenCookie(response, loginWrapper.getRefreshToken());
+		return ApiResponse.onSuccess(loginWrapper.getLoginResponse());
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/controller/UserController.java
+++ b/src/main/java/com/doyak/reflector/controller/UserController.java
@@ -108,4 +108,11 @@ public class UserController {
 		return ApiResponse.onSuccess(loginWrapper.getLoginResponse());
 	}
 	
+	@DeleteMapping("/logout")
+	@Operation(summary = "로그아웃", description = "현재 로그인한 사용자의 쿠키를 삭제합니다.")
+	public ApiResponse<Void> logout(@AuthenticationPrincipal User user, HttpServletResponse response) {
+		userService.logout(user);
+		cookieUtil.deleteRefreshTokenCookie(response);
+		return ApiResponse.onSuccess(null);
+	}
 }

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -1,9 +1,6 @@
 package com.doyak.reflector.converter;
 
-import java.time.LocalDate;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.doyak.reflector.domain.User;
@@ -13,10 +10,17 @@ import com.doyak.reflector.dto.request.UserRequest;
 
 public class UserConverter {
 	
-	public static UserResponse.UserLoginResponseDTO toLoginResponse(User user, String token) {
+	public static UserResponse.UserSignupResponseDTO toSignupResponse(User user) {
+		return UserResponse.UserSignupResponseDTO.builder()
+				.email(user.getEmail())
+				.build();
+	}
+	
+	public static UserResponse.UserLoginResponseDTO toLoginResponse(User user, String accessToken, String refreshToken) {
 		return UserResponse.UserLoginResponseDTO.builder()
 				.email(user.getEmail())
-				.token(token)
+				.accessToken(accessToken)
+				.refreshToken(refreshToken)
 				.build();
 	}
 	

--- a/src/main/java/com/doyak/reflector/converter/UserConverter.java
+++ b/src/main/java/com/doyak/reflector/converter/UserConverter.java
@@ -16,10 +16,16 @@ public class UserConverter {
 				.build();
 	}
 	
-	public static UserResponse.UserLoginResponseDTO toLoginResponse(User user, String accessToken, String refreshToken) {
+	public static UserResponse.UserLoginResponseDTO toLoginResponse(User user, String accessToken) {
 		return UserResponse.UserLoginResponseDTO.builder()
 				.email(user.getEmail())
 				.accessToken(accessToken)
+				.build();
+	}
+	
+	public static UserResponse.UserLoginWrapperDTO toLoginWrapper(UserResponse.UserLoginResponseDTO response, String refreshToken) {
+		return UserResponse.UserLoginWrapperDTO.builder()
+				.loginResponse(response)
 				.refreshToken(refreshToken)
 				.build();
 	}

--- a/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
+++ b/src/main/java/com/doyak/reflector/dto/request/UserRequest.java
@@ -17,10 +17,10 @@ public class UserRequest {
 	public static class UserLoginDTO {
 		
 		@NotBlank(message = "이메일을 입력해주세요.")
-		String email;
+		private String email;
 		
 		@NotBlank(message = "비밀번호를 입력해주세요.")
-		String password;
+		private String password;
 		
 	}
 	
@@ -31,10 +31,10 @@ public class UserRequest {
 	public static class UserSignUpDTO {
 		
 		@NotBlank(message = "이메일은 필수 입력 값입니다.")
-		String email;
+		private String email;
 		
 		@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-		String password;
+		private String password;
 	}
 	
 	@Builder
@@ -44,10 +44,10 @@ public class UserRequest {
 	public static class UserUpdateDTO {
 		
 		@NotBlank(message = "이메일을 입력해주세요. 변경하지 않을 것이라면 기존의 이메일을 입력해주세요.")
-		String email;
+		private String email;
 		
 		@NotBlank(message = "비밀번호를 입력해주세요. 변경하지 않을 것이라면 기존의 비밀번호를 입력해주세요.")
-		String password;
+		private String password;
 	}
   
 	@Builder
@@ -56,7 +56,7 @@ public class UserRequest {
 	@Getter
 	public static class UserEmailDTO {
 		@NotBlank(message = "이메일은 필수 입력 값입니다.")
-		String email;
+		private String email;
 	}
 	
 	@Builder
@@ -66,10 +66,23 @@ public class UserRequest {
 	public static class EmailCodeDTO {
 		
 		@NotBlank(message = "이메일은 필수 입력 값입니다.")
-		String email;
+		private String email;
 		
 		@Pattern(regexp = "^[0-9]{6}$", message = "인증 코드는 숫자 6자리여야 합니다.")
-		String code;
+		private String code;
+	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+	public static class TokenRequestDTO {
+		
+		@NotBlank
+		private String accessToken;
+		
+		@NotBlank
+		private String refreshToken;
 	}
 	
 }

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -25,6 +25,14 @@ public class UserResponse {
     public static class UserLoginResponseDTO {
 		private String email;
 		private String accessToken;
+	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class UserLoginWrapperDTO {
+		private UserLoginResponseDTO loginResponse;
 		private String refreshToken;
 	}
 	

--- a/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
+++ b/src/main/java/com/doyak/reflector/dto/response/UserResponse.java
@@ -14,9 +14,18 @@ public class UserResponse {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter
+    public static class UserSignupResponseDTO {
+		private String email;
+	}
+	
+	@Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
     public static class UserLoginResponseDTO {
 		private String email;
-		private String token;
+		private String accessToken;
+		private String refreshToken;
 	}
 	
 	@Builder

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -15,6 +15,7 @@ import com.doyak.reflector.converter.UserConverter;
 import com.doyak.reflector.domain.User;
 import com.doyak.reflector.repository.PostRepository;
 import com.doyak.reflector.repository.UserRepository;
+import com.doyak.reflector.util.RedisUtil;
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
@@ -33,6 +34,10 @@ public class UserService {
 	private final PostRepository postRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
+    
+    private int refreshTokenExpire = 1000*60*60*24;
+    private int accessTokenExpire = 1000*60*60;
     
     public void checkEmail(UserRequest.UserEmailDTO request) {
     	if (userRepository.findByEmail(request.getEmail()).isPresent())
@@ -49,7 +54,7 @@ public class UserService {
     	User newUser = UserConverter.toUser(request, encodedPassword);
         User savedUser = userRepository.save(newUser);
     	
-    	String accessToken = jwtUtil.createAccessToken(savedUser);
+    	String accessToken = jwtUtil.createToken("access", savedUser, 1000*60*5);
     	
     	return UserConverter.toLoginResponse(savedUser, accessToken);
     }
@@ -63,7 +68,10 @@ public class UserService {
             throw new UserHandler(ErrorStatus.INVALID_PASSWORD);
         }
 		
-		String accessToken = jwtUtil.createAccessToken(user);
+		String refreshToken = jwtUtil.createToken("refresh", user, refreshTokenExpire);
+		String accessToken = jwtUtil.createToken("access", user, accessTokenExpire);
+
+		redisUtil.setDataExpire("refreshToken: " + user.getEmail(), refreshToken, refreshTokenExpire);
 		
 		return UserConverter.toLoginResponse(user, accessToken);
 	}

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
     }
     
     @Transactional
-    public UserResponse.UserLoginResponseDTO signup(UserRequest.UserSignUpDTO request) {
+    public UserResponse.UserSignupResponseDTO signup(UserRequest.UserSignUpDTO request) {
     	if (userRepository.findByEmail(request.getEmail()).isPresent())
     		throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
     	
@@ -54,9 +54,7 @@ public class UserService {
     	User newUser = UserConverter.toUser(request, encodedPassword);
         User savedUser = userRepository.save(newUser);
     	
-    	String accessToken = jwtUtil.createToken("access", savedUser, 1000*60*5);
-    	
-    	return UserConverter.toLoginResponse(savedUser, accessToken);
+    	return UserConverter.toSignupResponse(savedUser);
     }
     
     @Transactional
@@ -73,7 +71,7 @@ public class UserService {
 
 		redisUtil.setDataExpire("refreshToken: " + user.getEmail(), refreshToken, refreshTokenExpire);
 		
-		return UserConverter.toLoginResponse(user, accessToken);
+		return UserConverter.toLoginResponse(user, accessToken, refreshToken);
 	}
     
     @Transactional

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -152,7 +152,7 @@ public class UserService {
         
 		return UserConverter.toLoginWrapper(UserConverter.toLoginResponse(user, newAccessToken), newRefreshToken);
     }
-    
+
     @Transactional
     public void logout(User user) {
         String email = user.getEmail();

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -132,7 +132,7 @@ public class UserService {
     }
     
     @Transactional
-    public UserResponse.UserLoginWrapperDTO reissue(String refreshToken) {
+    public UserResponse.UserLoginResponseDTO reissue(String refreshToken) {
     	
         if (!jwtUtil.validateToken(refreshToken)) {
             throw new UserHandler(ErrorStatus.NOT_VALID_TOKEN);
@@ -148,12 +148,9 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
         
-        String newRefreshToken = jwtUtil.createToken("refresh", user, refreshTokenExpire);
         String newAccessToken = jwtUtil.createToken("access", user, accessTokenExpire);
         
-        redisUtil.setDataExpire("refreshToken: " + user.getEmail(), newRefreshToken, refreshTokenExpire);   
-        
-		return UserConverter.toLoginWrapper(UserConverter.toLoginResponse(user, newAccessToken), newRefreshToken);
+		return UserConverter.toLoginResponse(user, newAccessToken);
     }
 
     @Transactional

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -16,6 +16,7 @@ import com.doyak.reflector.domain.User;
 import com.doyak.reflector.repository.PostRepository;
 import com.doyak.reflector.repository.UserRepository;
 import com.doyak.reflector.util.RedisUtil;
+
 import com.doyak.reflector.dto.request.UserRequest;
 import com.doyak.reflector.dto.response.UserResponse;
 import com.doyak.reflector.payload.code.status.ErrorStatus;
@@ -58,7 +59,7 @@ public class UserService {
     }
     
     @Transactional
-	public UserResponse.UserLoginResponseDTO login(UserRequest.UserLoginDTO request) {
+	public UserResponse.UserLoginWrapperDTO login(UserRequest.UserLoginDTO request) {
 		User user = userRepository.findByEmail(request.getEmail())
 				.orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 		
@@ -68,10 +69,10 @@ public class UserService {
 		
 		String refreshToken = jwtUtil.createToken("refresh", user, refreshTokenExpire);
 		String accessToken = jwtUtil.createToken("access", user, accessTokenExpire);
-
+		
 		redisUtil.setDataExpire("refreshToken: " + user.getEmail(), refreshToken, refreshTokenExpire);
 		
-		return UserConverter.toLoginResponse(user, accessToken, refreshToken);
+		return UserConverter.toLoginWrapper(UserConverter.toLoginResponse(user, accessToken), refreshToken);
 	}
     
     @Transactional
@@ -128,5 +129,33 @@ public class UserService {
         */
 
         return UserConverter.toTrackerResponse(queryResult);
+    }
+    
+    @Transactional
+    public UserResponse.UserLoginWrapperDTO reissue(String refreshToken) {
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new UserHandler(ErrorStatus.NOT_VALID_TOKEN);
+        }
+
+        String email = jwtUtil.getUserEmail(refreshToken);
+
+        String savedToken = redisUtil.getData("refreshToken: " + email);
+        if (savedToken == null || !savedToken.equals(refreshToken)) {
+            throw new UserHandler(ErrorStatus.WRONG_TYPE_TOKEN);
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        
+        String newRefreshToken = jwtUtil.createToken("refresh", user, refreshTokenExpire);
+        String newAccessToken = jwtUtil.createToken("access", user, accessTokenExpire);
+        
+		return UserConverter.toLoginWrapper(UserConverter.toLoginResponse(user, newAccessToken), newRefreshToken);
+    }
+    
+    @Transactional
+    public void logout(User user) {
+        String email = user.getEmail();
+        redisUtil.deleteData("refreshToken: " + email);
     }
 }

--- a/src/main/java/com/doyak/reflector/service/UserService.java
+++ b/src/main/java/com/doyak/reflector/service/UserService.java
@@ -133,6 +133,7 @@ public class UserService {
     
     @Transactional
     public UserResponse.UserLoginWrapperDTO reissue(String refreshToken) {
+    	
         if (!jwtUtil.validateToken(refreshToken)) {
             throw new UserHandler(ErrorStatus.NOT_VALID_TOKEN);
         }
@@ -149,6 +150,8 @@ public class UserService {
         
         String newRefreshToken = jwtUtil.createToken("refresh", user, refreshTokenExpire);
         String newAccessToken = jwtUtil.createToken("access", user, accessTokenExpire);
+        
+        redisUtil.setDataExpire("refreshToken: " + user.getEmail(), newRefreshToken, refreshTokenExpire);   
         
 		return UserConverter.toLoginWrapper(UserConverter.toLoginResponse(user, newAccessToken), newRefreshToken);
     }

--- a/src/main/java/com/doyak/reflector/util/CookieUtil.java
+++ b/src/main/java/com/doyak/reflector/util/CookieUtil.java
@@ -1,0 +1,40 @@
+package com.doyak.reflector.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.doyak.reflector.payload.code.status.ErrorStatus;
+import com.doyak.reflector.payload.exception.handler.UserHandler;
+
+@Component
+public class CookieUtil {
+	private final int defaultRefreshTokenExpire = 1000 * 60 * 60 * 24;
+	
+	public String getRefreshToken(HttpServletRequest request) {
+        return Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+                     .filter(c -> "refreshToken".equals(c.getName()))
+                     .findFirst()
+                     .map(Cookie::getValue)
+                     .orElseThrow(() -> new UserHandler(ErrorStatus.TOKEN_EXPIRED));
+    }
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        addRefreshTokenCookie(response, refreshToken, defaultRefreshTokenExpire);
+    }
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long expireMs) {
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge((int)(expireMs / 1000));
+        response.addCookie(cookie);
+    }
+
+}

--- a/src/main/java/com/doyak/reflector/util/CookieUtil.java
+++ b/src/main/java/com/doyak/reflector/util/CookieUtil.java
@@ -36,5 +36,14 @@ public class CookieUtil {
         cookie.setMaxAge((int)(expireMs / 1000));
         response.addCookie(cookie);
     }
+    
+    public void deleteRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
 
 }


### PR DESCRIPTION
<!-- PR제목 예시: [#12] 로그인 기능 구현 -->
close #35 

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
access token 만료 시간을 설정하고, refresh token 관련 구현을 추가하였습니다.

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 기존의 access token 만료 시간 설정
- 로그인 시 refresh token 생성, redis 저장, cookie에 담아 응답 반환
- redis에 저장된 refresh token 및 cookie에 담은 refresh token 삭제를 위한 로그아웃 API 추가

## 🧪 테스트 체크리스트
- [x] 로그인 응답으로 body에 access token, 쿠키에 refresh token 생성 확인
- [x] `POST /api/users/reissue` 호출로 access token 재발급 확인 (쿠키에 refresh token 값 필요)
- [x] request 헤더에 응답으로 받은 access token 추가, 로그아웃 api 호출 후 쿠키 삭제 확인
```
Authorization: Bearer <token>
``` 

## 💬 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- swagger 상으로 cookie에 대한 정보 확인이 불가능한 것 같아 postman으로 테스트 진행해주시면 감사하겠습니다 🙇‍♂️
- 우선 access token은 1시간, refresh token은 24시간으로 만료 시간 설정해두었습니다.

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?
